### PR TITLE
Handle multiple root modules correctly

### DIFF
--- a/slug.go
+++ b/slug.go
@@ -81,13 +81,14 @@ func packWalkFn(root, src, dst string, tarW *tar.Writer, meta *Meta, dereference
 		}
 
 		// Ignore any files in the .terraform directory.
-		if !info.IsDir() && filepath.Dir(subpath) == ".terraform" {
+		if !info.IsDir() && filepath.Base(filepath.Dir(subpath)) == ".terraform" {
 			return nil
 		}
 
 		// Skip .terraform subdirectories, except for the modules subdirectory.
-		if strings.HasPrefix(subpath, ".terraform"+string(filepath.Separator)) &&
-			!strings.HasPrefix(subpath, filepath.Clean(".terraform/modules")) {
+		if info.IsDir() &&
+			filepath.Base(filepath.Dir(subpath)) == ".terraform" &&
+			info.Name() != "modules" {
 			return filepath.SkipDir
 		}
 

--- a/slug_test.go
+++ b/slug_test.go
@@ -73,8 +73,10 @@ func TestPack(t *testing.T) {
 	// Make sure the .terraform directory is ignored,
 	// except for the .terraform/modules subdirectory.
 	for _, file := range fileList {
-		if strings.HasPrefix(file, ".terraform"+string(filepath.Separator)) &&
-			!strings.HasPrefix(file, filepath.Clean(".terraform/modules")) {
+		dirPath := filepath.Dir(file)
+		parentDirPath := filepath.Dir(dirPath)
+		if filepath.Base(parentDirPath) == ".terraform" &&
+			filepath.Base(dirPath) != "modules" {
 			t.Fatalf("unexpected .terraform content: %s", file)
 		}
 	}

--- a/testdata/archive-dir/sub/.terraform/modules/README
+++ b/testdata/archive-dir/sub/.terraform/modules/README
@@ -1,0 +1,2 @@
+Keep this file and directory here to test if its properly ignored
+

--- a/testdata/archive-dir/sub/.terraform/plugins/README
+++ b/testdata/archive-dir/sub/.terraform/plugins/README
@@ -1,0 +1,2 @@
+Keep this file and directory here to test if its properly ignored
+


### PR DESCRIPTION
In Terraform Enterprise, repositories can contain multiple terraform
root modules. Like following.

```
/ - project1/ - main.tf
  - project2/ - main.tf
```

With this repository structure, the current implementation cannot filter
out `project1/.terraform/plugins` and `project2/.terraform/plugins`,
because `.terraform` directories aren't located on a repository root.
This change filters out such directories and makes the remote plan
faster by reducing data transfer.

In our case, `.terraform/plugins` directories contain aws provider binaries.
The binaries are so large about 200MB per binary.
Our single repository has about 8 root modules, so sometimes we transfer more than 1.5GB to Terraform Enterprise in remote plan 😱 