### PR TITLE
Make default paths respect os.PathSeparator

### DIFF
--- a/terraformignore.go
+++ b/terraformignore.go
@@ -196,15 +196,15 @@ func (r *rule) compile() error {
 
 var defaultExclusions = []rule{
 	{
-		val:      "**/.git/**",
+		val:      strings.Join([]string{"**", ".git", "**"}, string(os.PathSeparator)),
 		excluded: false,
 	},
 	{
-		val:      "**/.terraform/**",
+		val:      strings.Join([]string{"**", ".terraform", "**"}, string(os.PathSeparator)),
 		excluded: false,
 	},
 	{
-		val:      "**/.terraform/modules/**",
+		val:      strings.Join([]string{"**", ".terraform", "modules", "**"}, string(os.PathSeparator)),
 		excluded: true,
 	},
 }


### PR DESCRIPTION
Default paths should use os.PathSeparator to be more general and friendly for our Windows-user friends.