### PR TITLE
Use filepath.Join instead of strings.Join for os compatibility

### DIFF
--- a/terraformignore.go
+++ b/terraformignore.go
@@ -196,15 +196,15 @@ func (r *rule) compile() error {
 
 var defaultExclusions = []rule{
 	{
-		val:      strings.Join([]string{"**", ".git", "**"}, string(os.PathSeparator)),
+		val:      filepath.Join("**", ".git", "**"),
 		excluded: false,
 	},
 	{
-		val:      strings.Join([]string{"**", ".terraform", "**"}, string(os.PathSeparator)),
+		val:      filepath.Join("**", ".terraform", "**"),
 		excluded: false,
 	},
 	{
-		val:      strings.Join([]string{"**", ".terraform", "modules", "**"}, string(os.PathSeparator)),
+		val:      filepath.Join("**", ".terraform", "modules", "**"),
 		excluded: true,
 	},
 }


### PR DESCRIPTION
This PR is very trivial.

#9 introduced multi-OS friendly .terraformignore feature.

The original implementation is enough, but I think it's better to use `filepath.Join` to do that.

`filepath` package is

> Package filepath implements utility routines for manipulating filename paths in a way compatible with the target operating system-defined file paths.

(ref : https://golang.org/pkg/path/filepath/

So, to support multi-OS, `filepath` helps. (and, code becomes much simple 👍 