### PR TITLE
enable GitHub code scanning workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,10 +1,9 @@
-name: "Code scanning - action"
+name: "Code scanning - scheduled (weekly) or on-demand"
 
 on:
-  push:
-    branches: [ enable-gh-code-scanning ]
-  pull_request:
-    branches: [ enable-gh-code-scanning ]
+  schedule:
+    - cron: '0 15 * * 0'
+  workflow_dispatch:
 
 jobs:
   CodeQL-Build:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,51 @@
+name: "Code scanning - action"
+
+on:
+  push:
+    branches: [ enable-gh-code-scanning ]
+  pull_request:
+    branches: [ enable-gh-code-scanning ]
+
+jobs:
+  CodeQL-Build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        # We must fetch at least the immediate parents so that if this is
+        # a pull request then we can checkout the head.
+        fetch-depth: 2
+
+    # If this run was triggered by a pull request event, then checkout
+    # the head of the pull request instead of the merge commit.
+    - run: git checkout HEAD^2
+      if: ${{ github.event_name == 'pull_request' }}
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      # Override language selection by uncommenting this and choosing your languages
+      with:
+        languages: go
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    # - name: Autobuild
+    #  uses: github/codeql-action/autobuild@v1
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 https://git.io/JvXDl
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #    and modify them (or add more) to build your code if your project
+    #    uses a compiled language
+
+    #- run: |
+    #   make bootstrap
+    #   make release
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
We're in the process of adopting GitHub "Advanced Security", which includes CodeQL code scanning capabilities.

This sets up the code scanning workflow to run against master as a scheduled weekly job & also on-demand via Actions UI. Results of scans will be available only to users with 'write' access to this repo, via the 'Security' tab (https://github.com/hashicorp/go-slug/security/code-scanning).