### PR TITLE
Fixes CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # go-slug
 
-[![Build Status](https://travis-ci.org/hashicorp/go-slug.svg?branch=master)](https://travis-ci.org/hashicorp/go-slug)
+[![Build Status](https://circleci.com/gh/hashicorp/go-slug.svg?style=svg)](https://app.circleci.com/pipelines/github/hashicorp/go-slug)
 [![GitHub license](https://img.shields.io/github/license/hashicorp/go-slug.svg)](https://github.com/hashicorp/go-slug/blob/master/LICENSE)
 [![GoDoc](https://godoc.org/github.com/hashicorp/go-slug?status.svg)](https://godoc.org/github.com/hashicorp/go-slug)
 [![Go Report Card](https://goreportcard.com/badge/github.com/hashicorp/go-slug)](https://goreportcard.com/report/github.com/hashicorp/go-slug)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # go-slug
 
-[![Build Status](https://circleci.com/gh/hashicorp/go-slug.svg?style=svg)](https://app.circleci.com/pipelines/github/hashicorp/go-slug)
+[![Build Status](https://circleci.com/gh/hashicorp/go-slug.svg?style=shield)](https://app.circleci.com/pipelines/github/hashicorp/go-slug)
 [![GitHub license](https://img.shields.io/github/license/hashicorp/go-slug.svg)](https://github.com/hashicorp/go-slug/blob/master/LICENSE)
 [![GoDoc](https://godoc.org/github.com/hashicorp/go-slug?status.svg)](https://godoc.org/github.com/hashicorp/go-slug)
 [![Go Report Card](https://goreportcard.com/badge/github.com/hashicorp/go-slug)](https://goreportcard.com/report/github.com/hashicorp/go-slug)


### PR DESCRIPTION
I noticed the build badge claimed to be failing, after I merged my last PR.

We're using CircleCI now, instead of Travis.

<img width="815" alt="Screen Shot 2020-12-11 at 2 18 57 PM" src="https://user-images.githubusercontent.com/3237030/101945189-d4337f80-3bbb-11eb-939f-03949bcffb03.png">
