### PR TITLE
Allow bypassing the .terraformignore rules

### DIFF
--- a/slug.go
+++ b/slug.go
@@ -77,6 +77,14 @@ func NewPacker(options ...PackerOption) (*Packer, error) {
 	return p, nil
 }
 
+// Pack at the package level is used to maintain compatibility with existing
+// code that relies on this function signature. New options related to packing
+// slugs should be added to the Packer struct instead.
+func Pack(src string, w io.Writer, dereference bool) (*Meta, error) {
+	p := Packer{dereference: dereference}
+	return p.Pack(src, w)
+}
+
 // Pack creates a slug from a src directory, and writes the new slug
 // to w. Returns metadata about the slug and any errors.
 //

--- a/slug.go
+++ b/slug.go
@@ -34,6 +34,49 @@ func (e *IllegalSlugError) Error() string {
 // chain.
 func (e *IllegalSlugError) Unwrap() error { return e.Err }
 
+// PackerOption is a functional option that can configure non-default Packers.
+type PackerOption func(*Packer) error
+
+// BypassIgnore is a PackerOption that will skip the .terraformignore rules and
+// Pack the entire src directory.
+func BypassIgnore() PackerOption {
+	return func(p *Packer) error {
+		p.bypassIgnore = true
+		return nil
+	}
+}
+
+// DereferenceSymlinks is a PackerOption that will allow symlinks that
+// reference a target outside of the src directory.
+func DereferenceSymlinks() PackerOption {
+	return func(p *Packer) error {
+		p.dereference = true
+		return nil
+	}
+}
+
+// Packer holds options for the Pack function.
+type Packer struct {
+	dereference  bool
+	bypassIgnore bool
+}
+
+// NewPacker is a constructor for Packer.
+func NewPacker(options ...PackerOption) (*Packer, error) {
+	p := &Packer{
+		dereference:  false,
+		bypassIgnore: false,
+	}
+
+	for _, opt := range options {
+		if err := opt(p); err != nil {
+			return nil, fmt.Errorf("option failed: %w", err)
+		}
+	}
+
+	return p, nil
+}
+
 // Pack creates a slug from a src directory, and writes the new slug
 // to w. Returns metadata about the slug and any errors.
 //
@@ -41,7 +84,7 @@ func (e *IllegalSlugError) Unwrap() error { return e.Err }
 // the src directory will be dereferenced. When dereference is set to
 // false symlinks with a target outside the src directory are omitted
 // from the slug.
-func Pack(src string, w io.Writer, dereference bool) (*Meta, error) {
+func (p *Packer) Pack(src string, w io.Writer) (*Meta, error) {
 	// Gzip compress all the output data.
 	gzipW := gzip.NewWriter(w)
 
@@ -50,13 +93,16 @@ func Pack(src string, w io.Writer, dereference bool) (*Meta, error) {
 
 	// Load the ignore rule configuration, which will use
 	// defaults if no .terraformignore is configured
-	ignoreRules := parseIgnoreFile(src)
+	var ignoreRules []rule
+	if !p.bypassIgnore {
+		ignoreRules = parseIgnoreFile(src)
+	}
 
 	// Track the metadata details as we go.
 	meta := &Meta{}
 
 	// Walk the tree of files.
-	err := filepath.Walk(src, packWalkFn(src, src, src, tarW, meta, dereference, ignoreRules))
+	err := filepath.Walk(src, packWalkFn(src, src, src, tarW, meta, p.dereference, ignoreRules))
 	if err != nil {
 		return nil, err
 	}

--- a/slug.go
+++ b/slug.go
@@ -37,11 +37,11 @@ func (e *IllegalSlugError) Unwrap() error { return e.Err }
 // PackerOption is a functional option that can configure non-default Packers.
 type PackerOption func(*Packer) error
 
-// ApplyIgnore is a PackerOption that will apply the .terraformignore rules and
-// skip packing files it specifies.
-func ApplyIgnore() PackerOption {
+// ApplyTerraformIgnore is a PackerOption that will apply the .terraformignore
+// rules and skip packing files it specifies.
+func ApplyTerraformIgnore() PackerOption {
 	return func(p *Packer) error {
-		p.applyIgnore = true
+		p.applyTerraformIgnore = true
 		return nil
 	}
 }
@@ -57,15 +57,15 @@ func DereferenceSymlinks() PackerOption {
 
 // Packer holds options for the Pack function.
 type Packer struct {
-	dereference bool
-	applyIgnore bool
+	dereference          bool
+	applyTerraformIgnore bool
 }
 
 // NewPacker is a constructor for Packer.
 func NewPacker(options ...PackerOption) (*Packer, error) {
 	p := &Packer{
-		dereference: false,
-		applyIgnore: false,
+		dereference:          false,
+		applyTerraformIgnore: false,
 	}
 
 	for _, opt := range options {
@@ -86,7 +86,7 @@ func Pack(src string, w io.Writer, dereference bool) (*Meta, error) {
 
 		// This defaults to false in NewPacker, but is true here. This matches
 		// the old behavior of Pack, which always used .terraformignore.
-		applyIgnore: true,
+		applyTerraformIgnore: true,
 	}
 	return p.Pack(src, w)
 }
@@ -108,7 +108,7 @@ func (p *Packer) Pack(src string, w io.Writer) (*Meta, error) {
 	// Load the ignore rule configuration, which will use
 	// defaults if no .terraformignore is configured
 	var ignoreRules []rule
-	if p.applyIgnore {
+	if p.applyTerraformIgnore {
 		ignoreRules = parseIgnoreFile(src)
 	}
 

--- a/slug_test.go
+++ b/slug_test.go
@@ -17,12 +17,7 @@ import (
 func TestPack(t *testing.T) {
 	slug := bytes.NewBuffer(nil)
 
-	p, err := NewPacker(DereferenceSymlinks())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	meta, err := p.Pack("testdata/archive-dir", slug)
+	meta, err := Pack("testdata/archive-dir", slug, true)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -146,12 +141,7 @@ func TestPack(t *testing.T) {
 func TestPackWithDereferencing(t *testing.T) {
 	slug := bytes.NewBuffer(nil)
 
-	p, err := NewPacker(DereferenceSymlinks())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	meta, err := p.Pack("testdata/archive-dir", slug)
+	meta, err := Pack("testdata/archive-dir", slug, true)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -201,12 +191,7 @@ func TestPackWithDereferencing(t *testing.T) {
 func TestPackWithoutDereferencing(t *testing.T) {
 	slug := bytes.NewBuffer(nil)
 
-	p, err := NewPacker()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	meta, err := p.Pack("testdata/archive-dir", slug)
+	meta, err := Pack("testdata/archive-dir", slug, false)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -259,12 +244,7 @@ func TestUnpack(t *testing.T) {
 	// First create the slug file so we can try to unpack it.
 	slug := bytes.NewBuffer(nil)
 
-	p, err := NewPacker(DereferenceSymlinks())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	if _, err := p.Pack("testdata/archive-dir", slug); err != nil {
+	if _, err := Pack("testdata/archive-dir", slug, true); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/slug_test.go
+++ b/slug_test.go
@@ -17,7 +17,12 @@ import (
 func TestPack(t *testing.T) {
 	slug := bytes.NewBuffer(nil)
 
-	meta, err := Pack("testdata/archive-dir", slug, true)
+	p, err := NewPacker(DereferenceSymlinks())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	meta, err := p.Pack("testdata/archive-dir", slug)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -141,7 +146,12 @@ func TestPack(t *testing.T) {
 func TestPackWithDereferencing(t *testing.T) {
 	slug := bytes.NewBuffer(nil)
 
-	meta, err := Pack("testdata/archive-dir", slug, true)
+	p, err := NewPacker(DereferenceSymlinks())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	meta, err := p.Pack("testdata/archive-dir", slug)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -191,7 +201,12 @@ func TestPackWithDereferencing(t *testing.T) {
 func TestPackWithoutDereferencing(t *testing.T) {
 	slug := bytes.NewBuffer(nil)
 
-	meta, err := Pack("testdata/archive-dir", slug, false)
+	p, err := NewPacker()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	meta, err := p.Pack("testdata/archive-dir", slug)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -244,7 +259,12 @@ func TestUnpack(t *testing.T) {
 	// First create the slug file so we can try to unpack it.
 	slug := bytes.NewBuffer(nil)
 
-	if _, err := Pack("testdata/archive-dir", slug, true); err != nil {
+	p, err := NewPacker(DereferenceSymlinks())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if _, err := p.Pack("testdata/archive-dir", slug); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/slug_test.go
+++ b/slug_test.go
@@ -243,7 +243,9 @@ func TestPackWithoutDereferencing(t *testing.T) {
 func TestPackWithoutIgnoring(t *testing.T) {
 	slug := bytes.NewBuffer(nil)
 
-	p, err := NewPacker(BypassIgnore())
+	// By default NewPacker() creates a Packer that does not use
+	// .terraformignore or dereference symlinks.
+	p, err := NewPacker()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -727,8 +729,8 @@ func TestNewPacker(t *testing.T) {
 		{
 			desc: "defaults",
 			expect: &Packer{
-				dereference:  false,
-				bypassIgnore: false,
+				dereference: false,
+				applyIgnore: false,
 			},
 		},
 		{
@@ -739,18 +741,18 @@ func TestNewPacker(t *testing.T) {
 			},
 		},
 		{
-			desc:    "disable .terraformignore",
-			options: []PackerOption{BypassIgnore()},
+			desc:    "apply .terraformignore",
+			options: []PackerOption{ApplyIgnore()},
 			expect: &Packer{
-				bypassIgnore: true,
+				applyIgnore: true,
 			},
 		},
 		{
 			desc:    "multiple options",
-			options: []PackerOption{BypassIgnore(), DereferenceSymlinks()},
+			options: []PackerOption{ApplyIgnore(), DereferenceSymlinks()},
 			expect: &Packer{
-				dereference:  true,
-				bypassIgnore: true,
+				dereference: true,
+				applyIgnore: true,
 			},
 		},
 	} {

--- a/slug_test.go
+++ b/slug_test.go
@@ -729,8 +729,8 @@ func TestNewPacker(t *testing.T) {
 		{
 			desc: "defaults",
 			expect: &Packer{
-				dereference: false,
-				applyIgnore: false,
+				dereference:          false,
+				applyTerraformIgnore: false,
 			},
 		},
 		{
@@ -742,17 +742,17 @@ func TestNewPacker(t *testing.T) {
 		},
 		{
 			desc:    "apply .terraformignore",
-			options: []PackerOption{ApplyIgnore()},
+			options: []PackerOption{ApplyTerraformIgnore()},
 			expect: &Packer{
-				applyIgnore: true,
+				applyTerraformIgnore: true,
 			},
 		},
 		{
 			desc:    "multiple options",
-			options: []PackerOption{ApplyIgnore(), DereferenceSymlinks()},
+			options: []PackerOption{ApplyTerraformIgnore(), DereferenceSymlinks()},
 			expect: &Packer{
-				dereference: true,
-				applyIgnore: true,
+				dereference:          true,
+				applyTerraformIgnore: true,
 			},
 		},
 	} {


### PR DESCRIPTION
While Terraform packing up configuration is one use of go-slug's Pack function, there are other uses not directly related to Terraform.

To that end, it'd be nice for the `.terraformignore` functionality to be optional. However, at the moment, it is not.

Even if `go-slug` user intentionally creates a blank `.terraformignore` file, the system is still "additive". The default rules are always applied.

This PR introduces a new struct, the `Packer` struct (ironically, completely unrelated to Packer the HashiCorp product).

The existing package level Pack function will keep its same function signature, but callers of `go-slug` can now create a custom Packer using functional options, which will have a simplified function signature.

One of those options will be to bypass the `.terraformignore` rules in this case, all the files in the src directory will be packed, no matter what.