### PR TITLE
perf: improve pack performance, implement tree pruning

### DIFF
--- a/slug.go
+++ b/slug.go
@@ -149,14 +149,21 @@ func packWalkFn(root, src, dst string, tarW *tar.Writer, meta *Meta, dereference
 			return nil
 		}
 
-		if m := matchIgnoreRule(subpath, ignoreRules); m {
-			return nil
+		if m, r := matchIgnoreRule(subpath, ignoreRules); m && !(r.val == "**/*" && info.IsDir()) {
+			if info.IsDir() {
+				return filepath.SkipDir
+			} else {
+				return nil
+			}
 		}
 
 		// Catch directories so we don't end up with empty directories,
 		// the files are ignored correctly
 		if info.IsDir() {
-			if m := matchIgnoreRule(subpath+string(os.PathSeparator), ignoreRules); m {
+			if m, r := matchIgnoreRule(subpath+string(os.PathSeparator), ignoreRules); m {
+				if r.val != "**/*" { // Represents the `*` rule
+					return filepath.SkipDir
+				}
 				return nil
 			}
 		}

--- a/slug_test.go
+++ b/slug_test.go
@@ -75,7 +75,7 @@ func TestPack(t *testing.T) {
 	// except for the .terraform/modules subdirectory.
 	for _, file := range fileList {
 		if strings.HasPrefix(file, ".terraform"+string(filepath.Separator)) &&
-			!strings.HasPrefix(file, filepath.Clean(".terraform/modules")) {
+			!strings.HasPrefix(file, filepath.Clean(".terraform/modules")) && file != ".terraform"+string(filepath.Separator) {
 			t.Fatalf("unexpected .terraform content: %s", file)
 		}
 	}

--- a/terraformignore_test.go
+++ b/terraformignore_test.go
@@ -7,7 +7,7 @@ import (
 func TestTerraformIgnore(t *testing.T) {
 	// path to directory without .terraformignore
 	p := parseIgnoreFile("testdata/external-dir")
-	if len(p) != 3 {
+	if len(p) != 4 {
 		t.Fatal("A directory without .terraformignore should get the default patterns")
 	}
 
@@ -22,6 +22,10 @@ func TestTerraformIgnore(t *testing.T) {
 	paths := []file{
 		{
 			path:  ".terraform/",
+			match: false,
+		},
+		{
+			path:  ".terraform/plugins",
 			match: true,
 		},
 		{
@@ -106,7 +110,7 @@ func TestTerraformIgnore(t *testing.T) {
 		},
 	}
 	for i, p := range paths {
-		match := matchIgnoreRule(p.path, ignoreRules)
+		match, _ := matchIgnoreRule(p.path, ignoreRules)
 		if match != p.match {
 			t.Fatalf("%s at index %d should be %t", p.path, i, p.match)
 		}


### PR DESCRIPTION
On a large repository (2^17 files, mostly ignored by git), this plus an appropriate `.terraformignore` improves performance from ~60 seconds to ~3 seconds.

Fixes #19 and #20.