### PR TITLE
update references to default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # go-slug
 
 [![Build Status](https://github.com/hashicorp/go-slug/actions/workflows/test.yml/badge.svg)](https://github.com/hashicorp/go-slug/actions/workflows/test.yml)
-[![GitHub license](https://img.shields.io/github/license/hashicorp/go-slug.svg)](https://github.com/hashicorp/go-slug/blob/master/LICENSE)
+[![GitHub license](https://img.shields.io/github/license/hashicorp/go-slug.svg)](https://github.com/hashicorp/go-slug/blob/main/LICENSE)
 [![GoDoc](https://godoc.org/github.com/hashicorp/go-slug?status.svg)](https://godoc.org/github.com/hashicorp/go-slug)
 [![Go Report Card](https://goreportcard.com/badge/github.com/hashicorp/go-slug)](https://goreportcard.com/report/github.com/hashicorp/go-slug)
 [![GitHub issues](https://img.shields.io/github/issues/hashicorp/go-slug.svg)](https://github.com/hashicorp/go-slug/issues)


### PR DESCRIPTION
This PR updates references to the default branch as part of the effort to rename the default branch to `main` across our repos.

The CI failure appears to be related to Circle <> Github permissions - it looks like we'll need to recreate the Circle SSH key.