### PR TITLE
Add terraform.tfstate to default exclusion list

### DIFF
--- a/terraformignore.go
+++ b/terraformignore.go
@@ -192,6 +192,7 @@ func (r *rule) compile() error {
 	.git/
 	.terraform/
 	!.terraform/modules/
+	terraform.tfstate
 */
 
 var defaultExclusions = []rule{
@@ -206,6 +207,10 @@ var defaultExclusions = []rule{
 	{
 		val:      filepath.Join("**", ".terraform", "modules", "**"),
 		excluded: true,
+	},
+	{
+		val:      filepath.Join("**", "terraform.tfstate"),
+		excluded: false,
 	},
 }
 

--- a/terraformignore_test.go
+++ b/terraformignore_test.go
@@ -7,7 +7,7 @@ import (
 func TestTerraformIgnore(t *testing.T) {
 	// path to directory without .terraformignore
 	p := parseIgnoreFile("testdata/external-dir")
-	if len(p) != 3 {
+	if len(p) != 4 {
 		t.Fatal("A directory without .terraformignore should get the default patterns")
 	}
 


### PR DESCRIPTION
TFE/TFC will return an error if `terraform.tfstate` is detected in the
slug that is uploaded to the remote agent. In TFE/TFC we read state from
the cloud rather than a state file, so we do not need `terraform.tfstate`
to be included in the slug.

This commit adds `terraform.tfstate` to the default exclusions list,
which is used if, and only if, there is no `.terraformignore` file
specified in the project directory. So if that file is included the
`terraform.tfstate` file WILL be included in the slug, unless of course
it is added to the `.terraformignore` file.

This gives us flexibility to have the default state file included if
needed and excluded by default.