### PR TITLE
Ignore pax headers during unpack

### DIFF
--- a/slug.go
+++ b/slug.go
@@ -386,7 +386,7 @@ func Unpack(r io.Reader, dst string) error {
 		}
 
 		// Only unpack regular files from this point on.
-		if header.Typeflag == tar.TypeDir {
+		if header.Typeflag == tar.TypeDir || header.Typeflag == tar.TypeXGlobalHeader || header.Typeflag == tar.TypeXHeader {
 			continue
 		} else if header.Typeflag != tar.TypeReg && header.Typeflag != tar.TypeRegA {
 			return fmt.Errorf("failed creating %q: unsupported type %c", path,


### PR DESCRIPTION
This PR adds checks to ignore pax headers when unpacking a slug. Currently, they are treated as normal files, leading to errors such as:

```
2022/04/20 18:17:52 failed creating "/var/folders/n0/z9w8y28d7j5dmnp0332cvv240000gp/T/slug1990756648/pax_global_header": unsupported type g
exit status 1
```

A similar change was introduced to go-getter's tar decompressor in https://github.com/hashicorp/go-getter/pull/75.

Example test program:

```go
package main

import (
	"io/ioutil"
	"log"
	"net/http"
	"os"

	"github.com/hashicorp/go-slug"
)

func main() {
	resp, err := http.Get("https://github.com/hashicorp/go-slug/archive/refs/tags/v0.8.0.tar.gz")
	if err != nil {
		log.Fatal(err)
	}
	defer resp.Body.Close()

	dst, err := ioutil.TempDir("", "slug")
	if err != nil {
		log.Fatal(err)
	}
	defer os.RemoveAll(dst)

	if err := slug.Unpack(resp.Body, dst); err != nil {
		log.Fatal(err)
	}
}
```