### PR TITLE
Support dangling symlinks

### DIFF
--- a/testdata/absolute-symlink/sym
+++ b/testdata/absolute-symlink/sym
@@ -1,0 +1,1 @@
+/some/absolute/path

--- a/testdata/archive-dir/dangling_symlink
+++ b/testdata/archive-dir/dangling_symlink
@@ -1,0 +1,1 @@
+nonexistent


### PR DESCRIPTION
Fixes an issue where a dangling symlink causes the `Pack()` function to fail. In general a dangling symlink is fairly innocuous, particularly so if the symlink is pointing to a path within the "root" of the archive. With this PR , dangling symlinks are now allowed so long as their targets remain _within_ the root of the archive.

This also adds some additional tests to verify that we handle dangling symlinks on the `Unpack()` side as well, and disallows absolute symlinks from being packed into a slug, which would inevitably error on the `Unpack()` side.

Fixes #18 