### PR TITLE
Resolve root dir if symlink

### DIFF
--- a/slug_test.go
+++ b/slug_test.go
@@ -17,126 +17,33 @@ import (
 
 func TestPack(t *testing.T) {
 	slug := bytes.NewBuffer(nil)
-
 	meta, err := Pack("testdata/archive-dir", slug, true)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	gzipR, err := gzip.NewReader(slug)
+	assertArchiveFixture(t, slug, meta)
+}
+
+func TestPack_rootIsSymlink(t *testing.T) {
+	err := os.Symlink("testdata/archive-dir", "testdata/archive-dir-symlink")
+	if err != nil {
+		t.Fatalf("Failed creating dir symlink: %v", err)
+	}
+	t.Cleanup(func() {
+		err := os.Remove("testdata/archive-dir-symlink")
+		if err != nil {
+			t.Fatalf("failed removing testdata/archive-dir-symlink: %v", err)
+		}
+	})
+
+	slug := bytes.NewBuffer(nil)
+	meta, err := Pack("testdata/archive-dir-symlink", slug, true)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	tarR := tar.NewReader(gzipR)
-	var (
-		symFound bool
-		fileList []string
-		slugSize int64
-	)
-
-	for {
-		hdr, err := tarR.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
-
-		fileList = append(fileList, hdr.Name)
-		if hdr.Typeflag == tar.TypeReg || hdr.Typeflag == tar.TypeRegA {
-			slugSize += hdr.Size
-		}
-
-		if hdr.Name == "sub/bar.txt" {
-			if hdr.Typeflag != tar.TypeSymlink {
-				t.Fatalf("expect symlink for file 'sub/bar.txt'")
-			}
-			if hdr.Linkname != "../bar.txt" {
-				t.Fatalf("expect target of '../bar.txt', got %q", hdr.Linkname)
-			}
-			symFound = true
-		}
-	}
-
-	// Make sure we saw and handled a symlink
-	if !symFound {
-		t.Fatal("expected to find symlink")
-	}
-
-	// Make sure the .git directory is ignored
-	for _, file := range fileList {
-		if strings.Contains(file, ".git") {
-			t.Fatalf("unexpected .git content: %s", file)
-		}
-	}
-
-	// Make sure the .terraform directory is ignored,
-	// except for the .terraform/modules subdirectory.
-	for _, file := range fileList {
-		if strings.HasPrefix(file, ".terraform"+string(filepath.Separator)) &&
-			!strings.HasPrefix(file, filepath.Clean(".terraform/modules")) {
-			t.Fatalf("unexpected .terraform content: %s", file)
-		}
-	}
-
-	// Make sure .terraform/modules is included.
-	moduleDir := false
-	for _, file := range fileList {
-		if strings.HasPrefix(file, filepath.Clean(".terraform/modules")) {
-			moduleDir = true
-			break
-		}
-	}
-	if !moduleDir {
-		t.Fatal("expected to include .terraform/modules")
-	}
-
-	// Make sure .terraformrc is included.
-	terraformrc := false
-	for _, file := range fileList {
-		if file == ".terraformrc" {
-			terraformrc = true
-			break
-		}
-	}
-	if !terraformrc {
-		t.Fatal("expected to include .terraformrc")
-	}
-
-	// Make sure foo.terraform/bar.txt is included.
-	fooTerraformDir := false
-	for _, file := range fileList {
-		if file == filepath.Clean("foo.terraform/bar.txt") {
-			fooTerraformDir = true
-			break
-		}
-	}
-	if !fooTerraformDir {
-		t.Fatal("expected to include foo.terraform/bar.txt")
-	}
-
-	// Make sure baz.txt is excluded.
-	bazTxt := false
-	for _, file := range fileList {
-		if file == filepath.Clean("baz.txt") {
-			bazTxt = true
-			break
-		}
-	}
-	if bazTxt {
-		t.Fatal("should not include baz.txt")
-	}
-
-	// Check the metadata
-	expect := &Meta{
-		Files: fileList,
-		Size:  slugSize,
-	}
-	if !reflect.DeepEqual(meta, expect) {
-		t.Fatalf("\nexpect:\n%#v\n\nactual:\n%#v", expect, meta)
-	}
+	assertArchiveFixture(t, slug, meta)
 }
 
 func TestPackWithoutIgnoring(t *testing.T) {
@@ -1098,6 +1005,124 @@ func TestNewPacker(t *testing.T) {
 				t.Fatalf("\nexpect:\n%#v\n\nactual:\n%#v", p, tc.expect)
 			}
 		})
+	}
+}
+
+// This is a reusable assertion for when packing testdata/archive-dir
+func assertArchiveFixture(t *testing.T, slug *bytes.Buffer, got *Meta) {
+	gzipR, err := gzip.NewReader(slug)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	tarR := tar.NewReader(gzipR)
+	var (
+		symFound bool
+		fileList []string
+		slugSize int64
+	)
+
+	for {
+		hdr, err := tarR.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		fileList = append(fileList, hdr.Name)
+		if hdr.Typeflag == tar.TypeReg || hdr.Typeflag == tar.TypeRegA {
+			slugSize += hdr.Size
+		}
+
+		if hdr.Name == "sub/bar.txt" {
+			if hdr.Typeflag != tar.TypeSymlink {
+				t.Fatalf("expect symlink for file 'sub/bar.txt'")
+			}
+			if hdr.Linkname != "../bar.txt" {
+				t.Fatalf("expect target of '../bar.txt', got %q", hdr.Linkname)
+			}
+			symFound = true
+		}
+	}
+
+	// Make sure we saw and handled a symlink
+	if !symFound {
+		t.Fatal("expected to find symlink")
+	}
+
+	// Make sure the .git directory is ignored
+	for _, file := range fileList {
+		if strings.Contains(file, ".git") {
+			t.Fatalf("unexpected .git content: %s", file)
+		}
+	}
+
+	// Make sure the .terraform directory is ignored,
+	// except for the .terraform/modules subdirectory.
+	for _, file := range fileList {
+		if strings.HasPrefix(file, ".terraform"+string(filepath.Separator)) &&
+			!strings.HasPrefix(file, filepath.Clean(".terraform/modules")) {
+			t.Fatalf("unexpected .terraform content: %s", file)
+		}
+	}
+
+	// Make sure .terraform/modules is included.
+	moduleDir := false
+	for _, file := range fileList {
+		if strings.HasPrefix(file, filepath.Clean(".terraform/modules")) {
+			moduleDir = true
+			break
+		}
+	}
+	if !moduleDir {
+		t.Fatal("expected to include .terraform/modules")
+	}
+
+	// Make sure .terraformrc is included.
+	terraformrc := false
+	for _, file := range fileList {
+		if file == ".terraformrc" {
+			terraformrc = true
+			break
+		}
+	}
+	if !terraformrc {
+		t.Fatal("expected to include .terraformrc")
+	}
+
+	// Make sure foo.terraform/bar.txt is included.
+	fooTerraformDir := false
+	for _, file := range fileList {
+		if file == filepath.Clean("foo.terraform/bar.txt") {
+			fooTerraformDir = true
+			break
+		}
+	}
+	if !fooTerraformDir {
+		t.Fatal("expected to include foo.terraform/bar.txt")
+	}
+
+	// Make sure baz.txt is excluded.
+	bazTxt := false
+	for _, file := range fileList {
+		if file == filepath.Clean("baz.txt") {
+			bazTxt = true
+			break
+		}
+	}
+	if bazTxt {
+		t.Fatal("should not include baz.txt")
+	}
+
+	// Check the metadata
+	expect := &Meta{
+		Files: fileList,
+		Size:  slugSize,
+	}
+	if !reflect.DeepEqual(got, expect) {
+		t.Fatalf("\nexpect:\n%#v\n\nactual:\n%#v", expect, got)
 	}
 }
 


### PR DESCRIPTION
This fix results from a bug where if the `src` directory to pack is a symlink, the resulting tar will contain no files. This attempts to resolve the symlink (if necessary) _before_ we begin to walk and archive the contents. 

To quickly reproduce this issue with Terraform:
1. Create any working directory. Ensure that the configuration is using the `cloud` or `backend "remote"` block. Run `terraform init`. 
1. Create a symlink: `ln -s /path/to/wkdir /path/to/wkdir-symlink`
1. `cd /path/to/wkdir-symlink && terraform apply`
1. You should see an error that no configuration files were found.  