### PR TITLE
Normalize relative paths to an absolute path

### DIFF
--- a/slug.go
+++ b/slug.go
@@ -158,6 +158,12 @@ func (p *Packer) Pack(src string, w io.Writer) (*Meta, error) {
 		ignoreRules = parseIgnoreFile(src)
 	}
 
+	// Ensure the source path provided is absolute
+	src, err = filepath.Abs(src)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read absolute path for source: %w", err)
+	}
+
 	// Walk the tree of files.
 	err = filepath.Walk(src, p.packWalkFn(src, src, src, tarW, meta, ignoreRules))
 	if err != nil {
@@ -264,7 +270,7 @@ func (p *Packer) packWalkFn(root, src, dst string, tarW *tar.Writer, meta *Meta,
 			// If the target is a directory we can recurse into the target
 			// directory by calling the packWalkFn with updated arguments.
 			if resolved.info.IsDir() {
-				return filepath.Walk(resolved.absTarget, p.packWalkFn(root, resolved.target, path, tarW, meta, ignoreRules))
+				return filepath.Walk(resolved.absTarget, p.packWalkFn(root, resolved.absTarget, path, tarW, meta, ignoreRules))
 			}
 
 			// Dereference this symlink by updating the header with the target file

--- a/testdata/archive-dir-absolute/_common/extra-files/bar.sh
+++ b/testdata/archive-dir-absolute/_common/extra-files/bar.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "bar"

--- a/testdata/archive-dir-absolute/_common/extra-files/foo.sh
+++ b/testdata/archive-dir-absolute/_common/extra-files/foo.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "foo"

--- a/testdata/archive-dir-absolute/_common/locals.tf
+++ b/testdata/archive-dir-absolute/_common/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  app = "service-01"
+}

--- a/testdata/archive-dir-absolute/_common/output.tf
+++ b/testdata/archive-dir-absolute/_common/output.tf
@@ -1,0 +1,7 @@
+locals {
+    files = fileset("${path.module}/extra-files", "*.sh")
+}
+
+output "scripts" {
+    value = local.files
+}

--- a/testdata/archive-dir-absolute/_common/versions.tf
+++ b/testdata/archive-dir-absolute/_common/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = "~> 1.2"
+}

--- a/testdata/archive-dir-absolute/dev/backend.tf
+++ b/testdata/archive-dir-absolute/dev/backend.tf
@@ -1,0 +1,10 @@
+terraform {
+  remote "backend" {
+    hostname     = "foobar.terraform.io"
+    organization = "hashicorp"
+
+    workspaces {
+      name = "dev-service-02"
+    }
+  }
+}

--- a/testdata/archive-dir-absolute/dev/extra-files
+++ b/testdata/archive-dir-absolute/dev/extra-files
@@ -1,0 +1,1 @@
+../_common/extra-files

--- a/testdata/archive-dir-absolute/dev/locals.tf
+++ b/testdata/archive-dir-absolute/dev/locals.tf
@@ -1,0 +1,1 @@
+../_common/locals.tf

--- a/testdata/archive-dir-absolute/dev/output.tf
+++ b/testdata/archive-dir-absolute/dev/output.tf
@@ -1,0 +1,1 @@
+../_common/output.tf

--- a/testdata/archive-dir-absolute/dev/variables.tf
+++ b/testdata/archive-dir-absolute/dev/variables.tf
@@ -1,0 +1,4 @@
+locals {
+  env    = "dev"
+  region = "us-east-2"
+}

--- a/testdata/archive-dir-absolute/dev/versions.tf
+++ b/testdata/archive-dir-absolute/dev/versions.tf
@@ -1,0 +1,1 @@
+../_common/versions.tf


### PR DESCRIPTION
## Description

This issue regarding dereferencing symlinks has plagued Terraform v1.3.0+ (reported for several versions [here](https://github.com/hashicorp/terraform/issues/31895)). The first issue, dereferencing symlinks whose targets resolve to symlinks _outside_ of the `src` directory was resolved in #37. The second issue, when the `src` directory itself is a symlink was resolved in #36. The last issue, and the focus of this PR, deals with normalizing paths when attempting to traverse the `src` directory. My change is simple: before attempting to traverse the `src` normalize the path representation to its absolute form. 

Big thank you to @willhughes-au and @calvinbui for providing the fixture used to test that paths are normalized. 

If you'd like to test that this works with Terraform, you will need to `go install .` from main, replacing the indirect dependency for go-slug with a repo containing these changes. 

```sh
cd /path/to/terraform
go mod edit -replace github.com/hashicorp/go-slug=/path/to/your/go-slug
go install .
```