### PR TITLE
sourceaddrs: Use correct canonical form for current directory

### DIFF
--- a/sourceaddrs/source.go
+++ b/sourceaddrs/source.go
@@ -33,7 +33,7 @@ func ParseSource(given string) (Source, error) {
 		return nil, fmt.Errorf("a valid source address is required")
 	}
 	switch {
-	case looksLikeLocalSource(given):
+	case looksLikeLocalSource(given) || given == "." || given == "..":
 		ret, err := ParseLocalSource(given)
 		if err != nil {
 			return nil, fmt.Errorf("invalid local source address %q: %w", given, err)

--- a/sourceaddrs/source_local.go
+++ b/sourceaddrs/source_local.go
@@ -45,7 +45,7 @@ func ParseLocalSource(given string) (LocalSource, error) {
 
 	// We distinguish local source addresses from other address types by them
 	// starting with some kind of relative path prefix.
-	if !looksLikeLocalSource(given) {
+	if !looksLikeLocalSource(given) && given != "." && given != ".." {
 		return LocalSource{}, fmt.Errorf("must start with either ./ or ../ to indicate a local path")
 	}
 
@@ -55,10 +55,12 @@ func ParseLocalSource(given string) (LocalSource, error) {
 	// exceptions:
 	// - we need to retain the leading "./", if it was originally present, to
 	//   disambiguate from module registry addresses.
-	// - If the cleaned path is just ".." then we need a slash on the end
+	// - If the cleaned path is just "." or ".." then we need a slash on the end
 	//   because that's part of how we recognize an address as a relative path.
 	if clean == ".." {
 		clean = "../"
+	} else if clean == "." {
+		clean = "./"
 	}
 	if !looksLikeLocalSource(clean) {
 		clean = "./" + clean

--- a/sourceaddrs/source_test.go
+++ b/sourceaddrs/source_test.go
@@ -45,6 +45,30 @@ func TestParseSource(t *testing.T) {
 			},
 		},
 		{
+			Given: "../",
+			Want: LocalSource{
+				relPath: "../",
+			},
+		},
+		{
+			Given:   "..",
+			WantErr: `invalid local source address "..": relative path must be written in canonical form "../"`,
+		},
+		{
+			Given: "./",
+			Want: LocalSource{
+				relPath: "./",
+			},
+		},
+		{
+			Given:   ".",
+			WantErr: `invalid local source address ".": relative path must be written in canonical form "./"`,
+		},
+		{
+			Given:   "./.",
+			WantErr: `invalid local source address "./.": relative path must be written in canonical form "./"`,
+		},
+		{
 			Given:   "../boop/../beep",
 			WantErr: `invalid local source address "../boop/../beep": relative path must be written in canonical form "../beep"`,
 		},

--- a/sourcebundle/diagnostics.go
+++ b/sourcebundle/diagnostics.go
@@ -128,7 +128,7 @@ func (diag diagnosticInSourcePackage) Severity() DiagSeverity {
 }
 
 func (diag diagnosticInSourcePackage) Source() DiagSource {
-	ret := diag.Source()
+	ret := diag.wrapped.Source()
 	if ret.Subject != nil && sourceaddrs.ValidSubPath(ret.Subject.Filename) {
 		newRng := *ret.Subject // shallow copy
 		newRng.Filename = diag.pkg.SourceAddr(newRng.Filename).String()


### PR DESCRIPTION
We previously missed an exception for making the canonical form of a local source referring to the current directory be `"./"`, to match the parent directory form `"../"`. This logic was incorrectly requiring that it be written as `"./."`, which is silly and inconsistent with Terraform CLI's current behavior.

Now `"./"` and `"../"` are both accepted as canonical forms, and naked `"."` and `".."` are still rejected as non-canonical as before, which we do just to avoid injecting further ambiguity into this already-rather-ambiguous source address syntax so that we'll have more options for potentially expanding this microsyntax in future.