### PR TITLE
Skip processing deleted directories during sourcebundle.Build

### DIFF
--- a/sourcebundle/builder.go
+++ b/sourcebundle/builder.go
@@ -13,10 +13,11 @@ import (
 	"sync"
 
 	"github.com/apparentlymart/go-versions/versions"
-	"github.com/hashicorp/go-slug/internal/ignorefiles"
-	"github.com/hashicorp/go-slug/sourceaddrs"
 	regaddr "github.com/hashicorp/terraform-registry-address"
 	"golang.org/x/mod/sumdb/dirhash"
+
+	"github.com/hashicorp/go-slug/internal/ignorefiles"
+	"github.com/hashicorp/go-slug/sourceaddrs"
 )
 
 // Builder deals with the process of gathering source code
@@ -651,7 +652,7 @@ func packagePrepareWalkFn(root string, ignoreRules *ignorefiles.Ruleset) filepat
 				if err != nil {
 					return fmt.Errorf("failed to remove ignored file %s: %s", relPath, err)
 				}
-				return nil
+				return filepath.SkipDir
 			}
 		}
 

--- a/sourcebundle/testdata/pkgs/terraformignore/.terraformignore
+++ b/sourcebundle/testdata/pkgs/terraformignore/.terraformignore
@@ -1,1 +1,2 @@
 excluded
+excluded-dir/


### PR DESCRIPTION
Previously, when building the source bundle, if an excluded directory had files in it, the build process would error because filepath.Walk computes the list of children for a directory before executing the walk function on that directory. Our function was deleting the directory (and all children) and then returning an error later when it tried to process (the now deleted) children.

Now, when we delete the directory we return the filepath.SkipDir directory which tells it to stop trying to recurse and it won't process the deleted children. 