### PR TITLE
Add `NormalizeUnpackFileModes` option to `Packer` struct

### DIFF
--- a/internal/unpackinfo/filemode.go
+++ b/internal/unpackinfo/filemode.go
@@ -53,7 +53,7 @@ func (m FileMode) ToFsFileMode() (fs.FileMode, error) {
 	case Plain:
 		return fs.FileMode(0644), nil
 	case Dir:
-		return fs.ModePerm | fs.ModeDir, nil
+		return fs.FileMode(0755) | fs.ModeDir, nil
 	case Executable:
 		return fs.FileMode(0755), nil
 	case Symlink:

--- a/internal/unpackinfo/filemode.go
+++ b/internal/unpackinfo/filemode.go
@@ -12,9 +12,9 @@ const (
 	Empty FileMode = 0
 	// Dir represent a Directory.
 	Dir FileMode = 0040000
-	// Regular represent non-executable files.  Please note this is not
+	// Plain represent non-executable, text files.  Please note this is not
 	// the same as golang regular files, which include executable files.
-	Regular FileMode = 0100644
+	Plain FileMode = 0100644
 	// Executable represents executable files.
 	Executable FileMode = 0100755
 	// Symlink represents symbolic links to files.
@@ -32,7 +32,7 @@ func NewFileMode(mode fs.FileMode) (FileMode, error) {
 			return Executable, nil
 		}
 
-		return Regular, nil
+		return Plain, nil
 	}
 
 	if mode.IsDir() {
@@ -50,7 +50,7 @@ func NewFileMode(mode fs.FileMode) (FileMode, error) {
 // permissions for regular and executable files.
 func (m FileMode) ToFsFileMode() (fs.FileMode, error) {
 	switch m {
-	case Regular:
+	case Plain:
 		return fs.FileMode(0644), nil
 	case Dir:
 		return fs.ModePerm | fs.ModeDir, nil
@@ -63,12 +63,12 @@ func (m FileMode) ToFsFileMode() (fs.FileMode, error) {
 	return fs.FileMode(0), fmt.Errorf("malformed file mode: %s", m)
 }
 
-func (m FileMode) IsRegular() bool {
-	return m == Regular
+func (m FileMode) IsPlain() bool {
+	return m == Plain
 }
 
 func (m FileMode) IsFile() bool {
-	return m == Regular ||
+	return m == Plain ||
 		m == Executable ||
 		m == Symlink
 }

--- a/internal/unpackinfo/filemode.go
+++ b/internal/unpackinfo/filemode.go
@@ -1,0 +1,93 @@
+package unpackinfo
+
+import (
+	"fmt"
+	"os"
+)
+
+type FileMode uint32
+
+const (
+	Empty FileMode = 0
+	// Dir represent a Directory.
+	Dir FileMode = 0040000
+	// Regular represent non-executable files.  Please note this is not
+	// the same as golang regular files, which include executable files.
+	Regular FileMode = 0100644
+	// Executable represents executable files.
+	Executable FileMode = 0100755
+	// Symlink represents symbolic links to files.
+	Symlink FileMode = 0120000
+)
+
+func New(mode os.FileMode) (FileMode, error) {
+	if mode.IsRegular() {
+		// disallow pipes, I/O, temporary files etc
+		if isCharDevice(mode) || isTemporary(mode) {
+			return Empty, fmt.Errorf("invalid file mode: %s", mode)
+		}
+
+		if isExecutable(mode) {
+			return Executable, nil
+		}
+
+		return Regular, nil
+	}
+
+	if mode.IsDir() {
+		return Dir, nil
+	}
+
+	if isSymlink(mode) {
+		return Symlink, nil
+	}
+
+	return Empty, fmt.Errorf("invalid file mode: %s", mode)
+}
+
+// Maps a FileMode integer to an os.FileMode type, normalizing
+// permissions for regular and executable files.
+func (m FileMode) ToOSFileMode() (os.FileMode, error) {
+	switch m {
+	case Regular:
+		return os.FileMode(0644), nil
+	case Dir:
+		return os.ModePerm | os.ModeDir, nil
+	case Executable:
+		return os.FileMode(0755), nil
+	case Symlink:
+		return os.ModePerm | os.ModeSymlink, nil
+	}
+
+	return os.FileMode(0), fmt.Errorf("malformed file mode: %s", m)
+}
+
+func (m FileMode) IsRegular() bool {
+	return m == Regular
+}
+
+func (m FileMode) IsFile() bool {
+	return m == Regular ||
+		m == Executable ||
+		m == Symlink
+}
+
+func (m FileMode) String() string {
+	return fmt.Sprintf("%07o", uint32(m))
+}
+
+func isCharDevice(m os.FileMode) bool {
+	return m&os.ModeCharDevice != 0
+}
+
+func isExecutable(m os.FileMode) bool {
+	return m&0100 != 0
+}
+
+func isSymlink(m os.FileMode) bool {
+	return m&os.ModeSymlink != 0
+}
+
+func isTemporary(m os.FileMode) bool {
+	return m&os.ModeTemporary != 0
+}

--- a/internal/unpackinfo/filemode.go
+++ b/internal/unpackinfo/filemode.go
@@ -2,6 +2,7 @@ package unpackinfo
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 )
 
@@ -20,7 +21,7 @@ const (
 	Symlink FileMode = 0120000
 )
 
-func NewFileMode(mode os.FileMode) (FileMode, error) {
+func NewFileMode(mode fs.FileMode) (FileMode, error) {
 	if mode.IsRegular() {
 		// disallow pipes, I/O, temporary files etc
 		if isCharDevice(mode) || isTemporary(mode) {
@@ -45,21 +46,21 @@ func NewFileMode(mode os.FileMode) (FileMode, error) {
 	return Empty, fmt.Errorf("invalid file mode: %s", mode)
 }
 
-// Maps a FileMode integer to an os.FileMode type, normalizing
+// Maps a FileMode integer to an fs.FileMode type, normalizing
 // permissions for regular and executable files.
-func (m FileMode) ToOSFileMode() (os.FileMode, error) {
+func (m FileMode) ToFsFileMode() (fs.FileMode, error) {
 	switch m {
 	case Regular:
-		return os.FileMode(0644), nil
+		return fs.FileMode(0644), nil
 	case Dir:
-		return os.ModePerm | os.ModeDir, nil
+		return fs.ModePerm | fs.ModeDir, nil
 	case Executable:
-		return os.FileMode(0755), nil
+		return fs.FileMode(0755), nil
 	case Symlink:
-		return os.ModePerm | os.ModeSymlink, nil
+		return fs.ModePerm | fs.ModeSymlink, nil
 	}
 
-	return os.FileMode(0), fmt.Errorf("malformed file mode: %s", m)
+	return fs.FileMode(0), fmt.Errorf("malformed file mode: %s", m)
 }
 
 func (m FileMode) IsRegular() bool {
@@ -76,18 +77,18 @@ func (m FileMode) String() string {
 	return fmt.Sprintf("%07o", uint32(m))
 }
 
-func isCharDevice(m os.FileMode) bool {
+func isCharDevice(m fs.FileMode) bool {
 	return m&os.ModeCharDevice != 0
 }
 
-func isExecutable(m os.FileMode) bool {
+func isExecutable(m fs.FileMode) bool {
 	return m&0100 != 0
 }
 
-func isSymlink(m os.FileMode) bool {
-	return m&os.ModeSymlink != 0
+func isSymlink(m fs.FileMode) bool {
+	return m&fs.ModeSymlink != 0
 }
 
-func isTemporary(m os.FileMode) bool {
-	return m&os.ModeTemporary != 0
+func isTemporary(m fs.FileMode) bool {
+	return m&fs.ModeTemporary != 0
 }

--- a/internal/unpackinfo/filemode.go
+++ b/internal/unpackinfo/filemode.go
@@ -20,7 +20,7 @@ const (
 	Symlink FileMode = 0120000
 )
 
-func New(mode os.FileMode) (FileMode, error) {
+func NewFileMode(mode os.FileMode) (FileMode, error) {
 	if mode.IsRegular() {
 		// disallow pipes, I/O, temporary files etc
 		if isCharDevice(mode) || isTemporary(mode) {

--- a/internal/unpackinfo/filemode_test.go
+++ b/internal/unpackinfo/filemode_test.go
@@ -1,0 +1,135 @@
+package unpackinfo
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+func assertFileMode(t *testing.T, expected FileMode, got FileMode) {
+	if expected != got {
+		t.Fatalf("expected filemode: %s, got: %s", expected, got)
+	}
+}
+
+func assertOSFileMode(t *testing.T, expected os.FileMode, got os.FileMode) {
+	if expected != got {
+		t.Fatalf("expected OS filemode: %s, got: %s", expected, got)
+	}
+}
+
+func TestFileMode_New(t *testing.T) {
+	for _, c := range []struct {
+		mode     os.FileMode
+		expected FileMode
+	}{
+		{os.FileMode(0755) | os.ModeDir, Dir},
+		{os.FileMode(0700) | os.ModeDir, Dir},
+		{os.FileMode(0500) | os.ModeDir, Dir},
+		// dirs with a sticky bit are just dirs
+		{os.FileMode(0755) | os.ModeDir | os.ModeSticky, Dir},
+		{os.FileMode(0644), Regular},
+		// append only files are regular
+		{os.FileMode(0644) | os.ModeAppend, Regular},
+		// exclusive only files are regular
+		{os.FileMode(0644) | os.ModeExclusive, Regular},
+		// depending on owner perms, setguid can be regular
+		{os.FileMode(0644) | os.ModeSetgid, Regular},
+		{os.FileMode(0660), Regular},
+		{os.FileMode(0640), Regular},
+		{os.FileMode(0600), Regular},
+		{os.FileMode(0400), Regular},
+		{os.FileMode(0000), Regular},
+		{os.FileMode(0755), Executable},
+		// setuid and setguid are executables
+		{os.FileMode(0755) | os.ModeSetuid, Executable},
+		{os.FileMode(0755) | os.ModeSetgid, Executable},
+		{os.FileMode(0700), Executable},
+		{os.FileMode(0500), Executable},
+		{os.FileMode(0744), Executable},
+		{os.FileMode(0540), Executable},
+		{os.FileMode(0550), Executable},
+		{os.FileMode(0777) | os.ModeSymlink, Symlink},
+	} {
+		m, err := New(c.mode)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertFileMode(t, c.expected, m)
+	}
+}
+
+func TestFileMode_NewWithErrors(t *testing.T) {
+	for _, c := range []struct {
+		mode        os.FileMode
+		expected    FileMode
+		expectedErr string
+	}{
+		// temporary files are ignored
+		{os.FileMode(0644) | os.ModeTemporary, Empty, "invalid file mode"},
+		// device files are ignored
+		{os.FileMode(0644) | os.ModeCharDevice, Empty, "invalid file mode"},
+		// named pipes are ignored
+		{os.FileMode(0644) | os.ModeNamedPipe, Empty, "invalid file mode"},
+		// sockets are ignored
+		{os.FileMode(0644) | os.ModeSocket, Empty, "invalid file mode"},
+	} {
+		m, err := New(c.mode)
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+		if !strings.Contains(err.Error(), c.expectedErr) {
+			t.Fatalf("unexpected error got: %v", err)
+		}
+
+		if m != c.expected {
+			t.Fatalf("expected empty file mode, got: %s", m)
+		}
+	}
+}
+
+func TestFileMode_ToOSFileMode(t *testing.T) {
+	for _, c := range []struct {
+		mode     FileMode
+		expected os.FileMode
+	}{
+		{Regular, os.FileMode(0644)},
+		{Dir, os.ModePerm | os.ModeDir},
+		{Symlink, os.ModePerm | os.ModeSymlink},
+		{Executable, os.FileMode(0755)},
+	} {
+		m, err := c.mode.ToOSFileMode()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertOSFileMode(t, c.expected, m)
+	}
+}
+
+func TestFileMode_ToOSFileModeWithErrors(t *testing.T) {
+	for _, mode := range []FileMode{
+		Empty,
+		FileMode(01),
+		FileMode(010),
+		FileMode(0100),
+		FileMode(01000),
+		FileMode(010000),
+		FileMode(0100000),
+	} {
+		m, err := mode.ToOSFileMode()
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+
+		expectedErr := fmt.Sprintf("malformed file mode: %s", mode)
+		gotErr := err.Error()
+		if gotErr != expectedErr {
+			t.Fatalf("expected error: %s, got: %s", expectedErr, gotErr)
+		}
+
+		if m != os.FileMode(0) {
+			t.Fatalf("expected file mode 0, got: %s", m)
+		}
+	}
+}

--- a/internal/unpackinfo/filemode_test.go
+++ b/internal/unpackinfo/filemode_test.go
@@ -29,18 +29,18 @@ func TestFileMode_New(t *testing.T) {
 		{fs.FileMode(0500) | fs.ModeDir, Dir},
 		// dirs with a sticky bit are just dirs
 		{fs.FileMode(0755) | fs.ModeDir | fs.ModeSticky, Dir},
-		{fs.FileMode(0644), Regular},
+		{fs.FileMode(0644), Plain},
 		// append only files are regular
-		{fs.FileMode(0644) | fs.ModeAppend, Regular},
+		{fs.FileMode(0644) | fs.ModeAppend, Plain},
 		// exclusive only files are regular
-		{fs.FileMode(0644) | fs.ModeExclusive, Regular},
+		{fs.FileMode(0644) | fs.ModeExclusive, Plain},
 		// depending on owner perms, setguid can be regular
-		{fs.FileMode(0644) | fs.ModeSetgid, Regular},
-		{fs.FileMode(0660), Regular},
-		{fs.FileMode(0640), Regular},
-		{fs.FileMode(0600), Regular},
-		{fs.FileMode(0400), Regular},
-		{fs.FileMode(0000), Regular},
+		{fs.FileMode(0644) | fs.ModeSetgid, Plain},
+		{fs.FileMode(0660), Plain},
+		{fs.FileMode(0640), Plain},
+		{fs.FileMode(0600), Plain},
+		{fs.FileMode(0400), Plain},
+		{fs.FileMode(0000), Plain},
 		{fs.FileMode(0755), Executable},
 		// setuid and setguid are executables
 		{fs.FileMode(0755) | fs.ModeSetuid, Executable},
@@ -94,7 +94,7 @@ func TestFileMode_ToOSFileMode(t *testing.T) {
 		mode     FileMode
 		expected fs.FileMode
 	}{
-		{Regular, fs.FileMode(0644)},
+		{Plain, fs.FileMode(0644)},
 		{Dir, fs.ModePerm | fs.ModeDir},
 		{Symlink, fs.ModePerm | fs.ModeSymlink},
 		{Executable, fs.FileMode(0755)},

--- a/internal/unpackinfo/filemode_test.go
+++ b/internal/unpackinfo/filemode_test.go
@@ -95,7 +95,7 @@ func TestFileMode_ToOSFileMode(t *testing.T) {
 		expected fs.FileMode
 	}{
 		{Plain, fs.FileMode(0644)},
-		{Dir, fs.ModePerm | fs.ModeDir},
+		{Dir, fs.FileMode(0755) | fs.ModeDir},
 		{Symlink, fs.ModePerm | fs.ModeSymlink},
 		{Executable, fs.FileMode(0755)},
 	} {

--- a/internal/unpackinfo/filemode_test.go
+++ b/internal/unpackinfo/filemode_test.go
@@ -52,7 +52,7 @@ func TestFileMode_New(t *testing.T) {
 		{os.FileMode(0550), Executable},
 		{os.FileMode(0777) | os.ModeSymlink, Symlink},
 	} {
-		m, err := New(c.mode)
+		m, err := NewFileMode(c.mode)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -75,7 +75,7 @@ func TestFileMode_NewWithErrors(t *testing.T) {
 		// sockets are ignored
 		{os.FileMode(0644) | os.ModeSocket, Empty, "invalid file mode"},
 	} {
-		m, err := New(c.mode)
+		m, err := NewFileMode(c.mode)
 		if err == nil {
 			t.Fatalf("expected an error, got nil")
 		}

--- a/internal/unpackinfo/unpackinfo.go
+++ b/internal/unpackinfo/unpackinfo.go
@@ -114,7 +114,7 @@ func (i *UnpackInfo) IsRegular() bool {
 	return i.Typeflag == tar.TypeReg || i.Typeflag == tar.TypeRegA
 }
 
-func (i *UnpackInfo) NormalizeMode() error {
+func (i *UnpackInfo) SetNormalizedMode() error {
 	mode, err := NewFileMode(i.OriginalMode)
 	if err != nil {
 		return fmt.Errorf("failed normalizing file permission: %w", err)

--- a/internal/unpackinfo/unpackinfo.go
+++ b/internal/unpackinfo/unpackinfo.go
@@ -182,7 +182,7 @@ func (i UnpackInfo) FileMode() (fs.FileMode, error) {
 	mode := i.OriginalMode
 
 	if i.NormalizedMode != Empty {
-		mode, err = i.NormalizedMode.ToOSFileMode()
+		mode, err = i.NormalizedMode.ToFsFileMode()
 		if err != nil {
 			return fs.FileMode(0), err
 		}

--- a/internal/unpackinfo/unpackinfo_test.go
+++ b/internal/unpackinfo/unpackinfo_test.go
@@ -115,7 +115,7 @@ func TestUnpackInfo_normalizedFileModes(t *testing.T) {
 
 		var expectedMode fs.FileMode
 		switch info.NormalizedMode {
-		case Regular:
+		case Plain:
 			expectedMode = fs.FileMode(0644)
 		case Dir:
 			expectedMode = os.ModePerm | os.ModeDir

--- a/internal/unpackinfo/unpackinfo_test.go
+++ b/internal/unpackinfo/unpackinfo_test.go
@@ -5,7 +5,6 @@ package unpackinfo
 
 import (
 	"archive/tar"
-	"io/fs"
 	"os"
 	"path"
 	"strings"
@@ -113,17 +112,14 @@ func TestUnpackInfo_normalizedFileModes(t *testing.T) {
 			t.Fatalf("failed to lstat %q: %s", info.Path, err)
 		}
 
-		var expectedMode fs.FileMode
-		switch info.NormalizedMode {
-		case Plain:
-			expectedMode = fs.FileMode(0644)
-		case Dir:
-			expectedMode = os.ModePerm | os.ModeDir
-		case Executable:
-			expectedMode = fs.FileMode(0755)
-		case Symlink:
-			// ignore symlinks
+		// ignore symlinks
+		if info.NormalizedMode == Symlink {
 			continue
+		}
+
+		expectedMode, err := info.FileMode()
+		if err != nil {
+			t.Fatalf("failed to read normalized file mode %s: %s", info.Path, err)
 		}
 
 		if stat.Mode() != expectedMode {

--- a/internal/unpackinfo/unpackinfo_test.go
+++ b/internal/unpackinfo/unpackinfo_test.go
@@ -100,7 +100,7 @@ func TestUnpackInfo_RestoreInfo(t *testing.T) {
 func TestUnpackInfo_normalizedFileModes(t *testing.T) {
 	cases := testUnpackInfoCases(t)
 	for _, info := range cases {
-		err := info.NormalizeMode()
+		err := info.SetNormalizedMode()
 		if err != nil {
 			t.Fatalf("failed normalizing permissions for %s: %s", info.Path, err)
 		}

--- a/internal/unpackinfo/unpackinfo_test.go
+++ b/internal/unpackinfo/unpackinfo_test.go
@@ -5,6 +5,7 @@ package unpackinfo
 
 import (
 	"archive/tar"
+	"io/fs"
 	"os"
 	"path"
 	"strings"
@@ -72,6 +73,66 @@ func TestNewUnpackInfo(t *testing.T) {
 }
 
 func TestUnpackInfo_RestoreInfo(t *testing.T) {
+	exampleModTime := time.Date(2023, time.May, 29, 11, 22, 33, 0, time.UTC)
+	cases := testUnpackInfoCases(t)
+	for _, info := range cases {
+		err := info.RestoreInfo()
+		if err != nil {
+			t.Errorf("failed to restore %q: %s", info.Path, err)
+		}
+		stat, err := os.Lstat(info.Path)
+		if err != nil {
+			t.Errorf("failed to lstat %q: %s", info.Path, err)
+		}
+
+		if !info.IsSymlink() {
+			if stat.Mode() != info.OriginalMode {
+				t.Errorf("%q mode %q did not match expected header mode %q", info.Path, stat.Mode(), info.OriginalMode)
+			}
+		} else if CanMaintainSymlinkTimestamps() {
+			if !stat.ModTime().Equal(exampleModTime) {
+				t.Errorf("%q modtime %q did not match example", info.Path, stat.ModTime())
+			}
+		}
+	}
+}
+
+func TestUnpackInfo_normalizedFileModes(t *testing.T) {
+	cases := testUnpackInfoCases(t)
+	for _, info := range cases {
+		err := info.NormalizeMode()
+		if err != nil {
+			t.Fatalf("failed normalizing permissions for %s: %s", info.Path, err)
+		}
+		err = info.RestoreInfo()
+		if err != nil {
+			t.Fatalf("failed to restore %q: %s", info.Path, err)
+		}
+		stat, err := os.Lstat(info.Path)
+		if err != nil {
+			t.Fatalf("failed to lstat %q: %s", info.Path, err)
+		}
+
+		var expectedMode fs.FileMode
+		switch info.NormalizedMode {
+		case Regular:
+			expectedMode = fs.FileMode(0644)
+		case Dir:
+			expectedMode = os.ModePerm | os.ModeDir
+		case Executable:
+			expectedMode = fs.FileMode(0755)
+		case Symlink:
+			// ignore symlinks
+			continue
+		}
+
+		if stat.Mode() != expectedMode {
+			t.Errorf("%q mode %q did not match normalized mode %q", info.Path, stat.Mode(), expectedMode)
+		}
+	}
+}
+
+func testUnpackInfoCases(t *testing.T) []*UnpackInfo {
 	root := t.TempDir()
 
 	err := os.Mkdir(path.Join(root, "subdir"), 0700)
@@ -82,6 +143,11 @@ func TestUnpackInfo_RestoreInfo(t *testing.T) {
 	err = os.WriteFile(path.Join(root, "bar.txt"), []byte("Hello, World!"), 0700)
 	if err != nil {
 		t.Fatalf("failed to create temp file: %s", err)
+	}
+
+	err = os.WriteFile(path.Join(root, "exefoobar"), []byte("echo Hello!"), 0755)
+	if err != nil {
+		t.Fatalf("failed to create executable file: %s", err)
 	}
 
 	err = os.Symlink(path.Join(root, "bar.txt"), path.Join(root, "foo.txt"))
@@ -125,26 +191,16 @@ func TestUnpackInfo_RestoreInfo(t *testing.T) {
 		t.Fatalf("failed to define linfo: %s", err)
 	}
 
-	infoCollection := []UnpackInfo{dirinfo, finfo, linfo}
-
-	for _, info := range infoCollection {
-		err = info.RestoreInfo()
-		if err != nil {
-			t.Errorf("failed to restore %q: %s", info.Path, err)
-		}
-		stat, err := os.Lstat(info.Path)
-		if err != nil {
-			t.Errorf("failed to lstat %q: %s", info.Path, err)
-		}
-
-		if !info.IsSymlink() {
-			if stat.Mode() != info.OriginalMode {
-				t.Errorf("%q mode %q did not match expected header mode %q", info.Path, stat.Mode(), info.OriginalMode)
-			}
-		} else if CanMaintainSymlinkTimestamps() {
-			if !stat.ModTime().Equal(exampleModTime) {
-				t.Errorf("%q modtime %q did not match example", info.Path, stat.ModTime())
-			}
-		}
+	exeinfo, err := NewUnpackInfo(root, &tar.Header{
+		Name:       "exefoobar",
+		Typeflag:   tar.TypeReg,
+		AccessTime: exampleAccessTime,
+		ModTime:    exampleModTime,
+		Mode:       0755,
+	})
+	if err != nil {
+		t.Fatalf("failed to define exeinfo: %s", err)
 	}
+
+	return []*UnpackInfo{dirinfo, finfo, linfo, exeinfo}
 }

--- a/slug.go
+++ b/slug.go
@@ -429,7 +429,7 @@ func (p *Packer) Unpack(r io.Reader, dst string) error {
 		}
 
 		if p.normalizeUnpackFileModes {
-			err = info.NormalizeMode()
+			err = info.SetNormalizedMode()
 			if err != nil {
 				return fmt.Errorf("failed normalizing mode: %w", err)
 			}


### PR DESCRIPTION
A recent change was introduced that preserves a file's original atime, mtime and mode when unpacked from a tarball. This consequently shifted responsibility to the slug's consumer to ensure each untarred file has the expected permissions. Inevitably this can lead to unpredictable errors, particularly if slugs are created by unknown sources and are expected to be handled uniformly. 

This PR aims to add a new packer option, `NormalizeUnpackFileModes`, that configures go-slug to normalize file modes when unpacking configuration files. This change aims to behave closely to how git normalizes permissions. The permissions for each type of file are encoded as follows:
- Regular, non-executable: 0644
- Regular, executable: 0755
- Directory: 040755
- Symlink: 0120777

All other file types are unsupported and result in an error: named pipes, char devices, sockets, etc. 

Example Usage:

```go
p, err := NewPacker(NormalizeUnpackFileModes(), DereferenceSymlinks())
if err != nil { // do a thing }

// Omitting code to handle packing or loading slug
if err = p.Unpack("/path/to/slug", "/path/to/destination"); err != nil {
  panic("whoops we made a booboo")
}
```
 