### PR TITLE
sourcebundle: Improve client extensibility

### DIFF
--- a/sourcebundle/package_fetcher.go
+++ b/sourcebundle/package_fetcher.go
@@ -10,7 +10,6 @@ import (
 
 // A PackageFetcher knows how to fetch remote source packages into a local
 // filesystem directory.
-//
 type PackageFetcher interface {
 	// FetchSourcePackage retrieves the a source package from the given
 	// location and extracts it into the given local filesystem directory.
@@ -35,5 +34,12 @@ type PackageFetcher interface {
 	// because it's [Builder]'s responsibility to handle caching and request
 	// coalescing during bundle construction to ensure that it will happen
 	// consistently across different fetcher implementations.
-	FetchSourcePackage(ctx context.Context, sourceType string, url *url.URL, targetDir string) (*PackageMeta, error)
+	FetchSourcePackage(ctx context.Context, sourceType string, url *url.URL, targetDir string) (FetchSourcePackageResponse, error)
+}
+
+// FetchSourcePackageResponse is a structure which represents metadata about
+// the fetch operation. This type may grow to add more data over time in later
+// minor releases.
+type FetchSourcePackageResponse struct {
+	PackageMeta *PackageMeta
 }

--- a/sourcebundle/registry_client.go
+++ b/sourcebundle/registry_client.go
@@ -21,11 +21,25 @@ import (
 // information such as the results of performing service discovery against
 // the hostname in a module package address.
 type RegistryClient interface {
-	// ModulePackageVersions returns all of the known exact versions
+	// ModulePackageVersions fetches all of the known exact versions
 	// available for the given package in its module registry.
-	ModulePackageVersions(ctx context.Context, pkgAddr regaddr.ModulePackage) (versions.List, error)
+	ModulePackageVersions(ctx context.Context, pkgAddr regaddr.ModulePackage) (ModulePackageVersionsResponse, error)
 
-	// ModulePackageSourceAddr returns the real remote source address for the
+	// ModulePackageSourceAddr fetches the real remote source address for the
 	// given version of the given module registry package.
-	ModulePackageSourceAddr(ctx context.Context, pkgAddr regaddr.ModulePackage, version versions.Version) (sourceaddrs.RemoteSource, error)
+	ModulePackageSourceAddr(ctx context.Context, pkgAddr regaddr.ModulePackage, version versions.Version) (ModulePackageSourceAddrResponse, error)
+}
+
+// ModulePackageVersionsResponse is an opaque type which represents the result
+// of the package versions client operation. This type may grow to add more
+// functionality over time in later minor releases.
+type ModulePackageVersionsResponse struct {
+	Versions versions.List
+}
+
+// ModulePackageSourceAddrResponse is an opaque type which represents the
+// result of the source address client operation. This type may grow to add
+// more functionality over time in later minor releases.
+type ModulePackageSourceAddrResponse struct {
+	SourceAddr sourceaddrs.RemoteSource
 }


### PR DESCRIPTION
The package fetcher and registry client interfaces previously returned only the data we currently support. This makes it difficult to add more data and metadata in future updates to this library, as each addition will be a breaking change.

This commit adds trivial wrapping types around these response values, allowing us to easily add more fields to those types when we have more data to return, without forcing a new major version.