### PR TITLE
fix: PackageMeta builder excluding gitCommitMessage

### DIFF
--- a/sourcebundle/package_meta.go
+++ b/sourcebundle/package_meta.go
@@ -37,7 +37,8 @@ func PackageMetaWithGitMetadata(
 	commitMessage string,
 ) *PackageMeta {
 	return &PackageMeta{
-		gitCommitID: commitID,
+		gitCommitID:      commitID,
+		gitCommitMessage: commitMessage,
 	}
 }
 


### PR DESCRIPTION
Fixes issue with retrieving the git commit message meta when calling PackageMeta receiver method, `GitCommitMessage() string`