### PR TITLE
sourcebundle: Fix panic when RegistryMeta and Packages aren't the same size

### DIFF
--- a/sourcebundle/builder.go
+++ b/sourcebundle/builder.go
@@ -622,7 +622,7 @@ func (b *Builder) writeManifest(filename string) error {
 	}
 
 	sort.Slice(root.RegistryMeta, func(i, j int) bool {
-		return root.Packages[i].SourceAddr < root.Packages[j].SourceAddr
+		return root.RegistryMeta[i].SourceAddr < root.RegistryMeta[j].SourceAddr
 	})
 
 	buf, err := json.MarshalIndent(&root, "", "  ")


### PR DESCRIPTION
Seems like a copy-paste error here. I think this works most of the time because packages and registrymeta are usually the same size. But, if someone loads a package directly from Github (or another source) without going through the registry this panics.