### PR TITLE
Add CODEOWNERS file in .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Each line is a file pattern followed by one or more owners.
+# More on CODEOWNERS files: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# Default owner
+* @hashicorp/team-ip-compliance
+
+# Add override rules below. Each line is a file/folder pattern followed by one or more owners.
+# Being an owner means those groups or individuals will be added as reviewers to PRs affecting
+# those areas of the code.
+# Examples:
+# /docs/  @docs-team
+# *.js    @js-team
+# *.go    @go-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,4 +10,4 @@
 # Examples:
 # /docs/  @docs-team
 # *.js    @js-team
-# *.go    @go-team
+# *.go    @go-team 


### PR DESCRIPTION
Add CODEOWNERS file to define code ownership rules.

This PR adds a CODEOWNERS file in .github/CODEOWNERS to help manage code review assignments and maintain clear ownership of different parts of the codebase.