### PR TITLE
fix: bug in prefix and suffix check using filepath

### DIFF
--- a/internal/unpackinfo/unpackinfo.go
+++ b/internal/unpackinfo/unpackinfo.go
@@ -37,19 +37,14 @@ func NewUnpackInfo(dst string, header *tar.Header) (UnpackInfo, error) {
 
 	// Clean the destination path
 	dst = filepath.Clean(dst)
-
-	// Get rid of absolute paths.
-	path := header.Name
-	if filepath.IsAbs(path) {
-		path = path[1:]
-	}
+	path := filepath.Clean(header.Name)
 
 	path = filepath.Join(dst, path)
 	target := filepath.Clean(path)
 
 	// Check for path traversal by ensuring the target is within the destination
 	rel, err := filepath.Rel(dst, target)
-	if err != nil || strings.HasPrefix(rel, "..") || strings.Contains(dst, "..") || strings.Contains(target, "..") || filepath.IsAbs(rel) {
+	if err != nil || strings.HasPrefix(rel, "..") || strings.Contains(dst, "..") || strings.Contains(path, "..") || strings.Contains(target, "..") {
 		return UnpackInfo{}, errors.New("invalid filename, traversal with \"..\" outside of current directory")
 	}
 

--- a/internal/unpackinfo/unpackinfo.go
+++ b/internal/unpackinfo/unpackinfo.go
@@ -44,7 +44,7 @@ func NewUnpackInfo(dst string, header *tar.Header) (UnpackInfo, error) {
 
 	// Check for path traversal by ensuring the target is within the destination
 	rel, err := filepath.Rel(dst, target)
-	if err != nil || strings.HasPrefix(rel, "..") || strings.Contains(dst, "..") || strings.Contains(path, "..") {
+	if err != nil || strings.HasPrefix(rel, "..") {
 		return UnpackInfo{}, errors.New("invalid filename, traversal with \"..\" outside of current directory")
 	}
 

--- a/internal/unpackinfo/unpackinfo.go
+++ b/internal/unpackinfo/unpackinfo.go
@@ -44,7 +44,7 @@ func NewUnpackInfo(dst string, header *tar.Header) (UnpackInfo, error) {
 
 	// Check for path traversal by ensuring the target is within the destination
 	rel, err := filepath.Rel(dst, target)
-	if err != nil || strings.HasPrefix(rel, "..") || strings.Contains(dst, "..") || strings.Contains(path, "..") || strings.Contains(target, "..") {
+	if err != nil || strings.HasPrefix(rel, "..") || strings.Contains(dst, "..") || strings.Contains(path, "..") {
 		return UnpackInfo{}, errors.New("invalid filename, traversal with \"..\" outside of current directory")
 	}
 

--- a/internal/unpackinfo/unpackinfo.go
+++ b/internal/unpackinfo/unpackinfo.go
@@ -49,13 +49,8 @@ func NewUnpackInfo(dst string, header *tar.Header) (UnpackInfo, error) {
 
 	// Check for path traversal by ensuring the target is within the destination
 	rel, err := filepath.Rel(dst, target)
-	if err != nil || strings.HasPrefix(rel, "..") || filepath.IsAbs(rel) {
+	if err != nil || strings.HasPrefix(rel, "..") || strings.Contains(dst, "..") || strings.Contains(target, "..") || filepath.IsAbs(rel) {
 		return UnpackInfo{}, errors.New("invalid filename, traversal with \"..\" outside of current directory")
-	}
-
-	// Additional check for path traversal in the destination and target
-	if strings.Contains(dst, "..") || strings.Contains(target, "..") {
-		return UnpackInfo{}, errors.New("invalid path, traversal with \"..\" is not allowed")
 	}
 
 	// Ensure the destination is not through any symlinks. This prevents

--- a/internal/unpackinfo/unpackinfo_test.go
+++ b/internal/unpackinfo/unpackinfo_test.go
@@ -152,6 +152,42 @@ func TestNewUnpackInfo(t *testing.T) {
 			t.Fatalf("expected nil, got %q", err)
 		}
 	})
+	t.Run("valid path multiple / prefix", func(t *testing.T) {
+		dst := t.TempDir()
+
+		_, err := NewUnpackInfo(dst, &tar.Header{
+			Name:     "///////foo",
+			Typeflag: tar.TypeSymlink,
+		})
+
+		if err != nil {
+			t.Fatalf("expected nil, got %q", err)
+		}
+	})
+	t.Run("valid path with / sufix", func(t *testing.T) {
+		dst := t.TempDir()
+
+		_, err := NewUnpackInfo(dst, &tar.Header{
+			Name:     "foo/",
+			Typeflag: tar.TypeSymlink,
+		})
+
+		if err != nil {
+			t.Fatalf("expected nil, got %q", err)
+		}
+	})
+	t.Run("valid destination with / prefix", func(t *testing.T) {
+		dst := "/" + t.TempDir()
+
+		_, err := NewUnpackInfo(dst, &tar.Header{
+			Name:     "foo/",
+			Typeflag: tar.TypeSymlink,
+		})
+
+		if err != nil {
+			t.Fatalf("expected nil, got %q", err)
+		}
+	})
 	t.Run("valid symlink", func(t *testing.T) {
 		dst := t.TempDir()
 

--- a/internal/unpackinfo/unpackinfo_test.go
+++ b/internal/unpackinfo/unpackinfo_test.go
@@ -145,7 +145,8 @@ func TestNewUnpackInfo(t *testing.T) {
 		}
 	})
 	t.Run("destination starting with ./", func(t *testing.T) {
-		outsideDst := filepath.Join("./" + t.TempDir())
+		dst := t.TempDir()
+		outsideDst := "./" + dst
 		result, err := NewUnpackInfo(outsideDst, &tar.Header{
 			Name:     "foo.txt",
 			Typeflag: tar.TypeSymlink,
@@ -163,8 +164,23 @@ func TestNewUnpackInfo(t *testing.T) {
 
 	t.Run("destination starting with ./ followed with ../", func(t *testing.T) {
 		dst := t.TempDir()
-		outsideDst := filepath.Join("./../../" + dst)
-		_, err := NewUnpackInfo(outsideDst, &tar.Header{
+		_, err := NewUnpackInfo("./../../"+dst, &tar.Header{
+			Name:     "foo.txt",
+			Typeflag: tar.TypeSymlink,
+		})
+
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		expected := "traversal with \"..\" outside of current"
+		if !strings.Contains(err.Error(), expected) {
+			t.Fatalf("expected error to contain %q, got %q", expected, err)
+		}
+	})
+	t.Run("destination followed with ../", func(t *testing.T) {
+		dst := t.TempDir()
+		_, err := NewUnpackInfo(dst+"../../foo", &tar.Header{
 			Name:     "foo.txt",
 			Typeflag: tar.TypeSymlink,
 		})

--- a/internal/unpackinfo/unpackinfo_test.go
+++ b/internal/unpackinfo/unpackinfo_test.go
@@ -111,6 +111,83 @@ func TestNewUnpackInfo(t *testing.T) {
 			t.Fatalf("expected error to contain %q, got %q", expected, err)
 		}
 	})
+	t.Run("empty destination", func(t *testing.T) {
+		emptyDestination := ""
+		_, err := NewUnpackInfo(emptyDestination, &tar.Header{
+			Name:     "foo.txt",
+			Typeflag: tar.TypeSymlink,
+		})
+
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		expected := "empty destination is not allowed"
+		if !strings.Contains(err.Error(), expected) {
+			t.Fatalf("expected error to contain %q, got %q", expected, err)
+		}
+	})
+	t.Run("valid empty path", func(t *testing.T) {
+		dst := t.TempDir()
+
+		_, err := NewUnpackInfo(dst, &tar.Header{
+			Name:     "",
+			Typeflag: tar.TypeSymlink,
+		})
+
+		if err != nil {
+			t.Fatalf("expected nil, got %q", err)
+		}
+	})
+	t.Run("valid empty path with destination without the / sufix", func(t *testing.T) {
+		dst := t.TempDir()
+		dst = strings.TrimSuffix(dst, "/")
+
+		_, err := NewUnpackInfo(dst, &tar.Header{
+			Name:     "",
+			Typeflag: tar.TypeSymlink,
+		})
+
+		if err != nil {
+			t.Fatalf("expected nil, got %q", err)
+		}
+	})
+	t.Run("valid symlink", func(t *testing.T) {
+		dst := t.TempDir()
+
+		_, err := NewUnpackInfo(dst, &tar.Header{
+			Name:     "foo.txt",
+			Typeflag: tar.TypeSymlink,
+		})
+
+		if err != nil {
+			t.Fatalf("expected nil, got %q", err)
+		}
+	})
+	t.Run("valid file", func(t *testing.T) {
+		dst := t.TempDir()
+
+		_, err := NewUnpackInfo(dst, &tar.Header{
+			Name:     "foo.txt",
+			Typeflag: tar.TypeReg,
+		})
+
+		if err != nil {
+			t.Fatalf("expected nil, got %q", err)
+		}
+	})
+	t.Run("valid directory", func(t *testing.T) {
+		dst := t.TempDir()
+
+		_, err := NewUnpackInfo(dst, &tar.Header{
+			Name:     "foo",
+			Typeflag: tar.TypeDir,
+		})
+
+		if err != nil {
+			t.Fatalf("expected nil, got %q", err)
+		}
+	})
 }
 
 func TestUnpackInfo_RestoreInfo(t *testing.T) {

--- a/internal/unpackinfo/unpackinfo_test.go
+++ b/internal/unpackinfo/unpackinfo_test.go
@@ -163,19 +163,19 @@ func TestNewUnpackInfo(t *testing.T) {
 
 	t.Run("destination starting with ./ followed with ../", func(t *testing.T) {
 		dst := t.TempDir()
-		outsideDst := filepath.Join("./../../" + t.TempDir())
-		result, err := NewUnpackInfo(outsideDst, &tar.Header{
+		outsideDst := filepath.Join("./../../" + dst)
+		_, err := NewUnpackInfo(outsideDst, &tar.Header{
 			Name:     "foo.txt",
 			Typeflag: tar.TypeSymlink,
 		})
 
-		if err != nil {
-			t.Fatalf("expected nil, got %q", err)
+		if err == nil {
+			t.Fatal("expected error, got nil")
 		}
 
-		expected := filepath.Join(dst, "foo.txt")
-		if result.Path != expected {
-			t.Fatalf("expected error to contain %q, got %q", expected, result.Path)
+		expected := "traversal with \"..\" outside of current"
+		if !strings.Contains(err.Error(), expected) {
+			t.Fatalf("expected error to contain %q, got %q", expected, err)
 		}
 	})
 	t.Run("empty destination", func(t *testing.T) {

--- a/internal/unpackinfo/unpackinfo_test.go
+++ b/internal/unpackinfo/unpackinfo_test.go
@@ -161,39 +161,6 @@ func TestNewUnpackInfo(t *testing.T) {
 			t.Fatalf("expected error to contain %q, got %q", expected, result.Path)
 		}
 	})
-
-	t.Run("destination starting with ./ followed with ../", func(t *testing.T) {
-		dst := t.TempDir()
-		_, err := NewUnpackInfo("./../../"+dst, &tar.Header{
-			Name:     "foo.txt",
-			Typeflag: tar.TypeSymlink,
-		})
-
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
-
-		expected := "traversal with \"..\" outside of current"
-		if !strings.Contains(err.Error(), expected) {
-			t.Fatalf("expected error to contain %q, got %q", expected, err)
-		}
-	})
-	t.Run("destination followed with ../", func(t *testing.T) {
-		dst := t.TempDir()
-		_, err := NewUnpackInfo(dst+"../../foo", &tar.Header{
-			Name:     "foo.txt",
-			Typeflag: tar.TypeSymlink,
-		})
-
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
-
-		expected := "traversal with \"..\" outside of current"
-		if !strings.Contains(err.Error(), expected) {
-			t.Fatalf("expected error to contain %q, got %q", expected, err)
-		}
-	})
 	t.Run("empty destination", func(t *testing.T) {
 		emptyDestination := ""
 		_, err := NewUnpackInfo(emptyDestination, &tar.Header{


### PR DESCRIPTION
Alternative to https://github.com/hashicorp/go-slug/pull/77 but using`"path/filepath"` instead of strings. 
Resolves a bug where the prefix check doesn't work on empty path.

Testing with real tarballs ([ref](https://github.com/hashicorp/security-vulnerabilities/pull/362))