### PR TITLE
irregular mode file checks for Windows symlinks

### DIFF
--- a/slug.go
+++ b/slug.go
@@ -151,7 +151,7 @@ func (p *Packer) Pack(src string, w io.Writer) (*Meta, error) {
 	}
 
 	// Check if the root (src) is a symlink
-	if info.Mode()&os.ModeSymlink != 0 {
+	if isSymlink(info.Mode()) {
 		src, err = os.Readlink(src)
 		if err != nil {
 			return nil, err
@@ -257,7 +257,7 @@ func (p *Packer) packWalkFn(root, src, dst string, tarW *tar.Writer, meta *Meta,
 			header.Typeflag = tar.TypeReg
 			header.Size = info.Size()
 
-		case fm&os.ModeSymlink != 0:
+		case isSymlink(info.Mode()):
 			// Read the symlink file to find the destination.
 			target, err := os.Readlink(path)
 			if err != nil {
@@ -358,7 +358,7 @@ func (p *Packer) resolveExternalLink(root string, path string) (*externalSymlink
 	}
 
 	// Recurse if the symlink resolves to another symlink
-	if info.Mode()&os.ModeSymlink != 0 {
+	if isSymlink(info.Mode()) {
 		return p.resolveExternalLink(root, absTarget)
 	}
 
@@ -562,9 +562,15 @@ func checkFileMode(m os.FileMode) (keep, body bool) {
 	case m.IsRegular():
 		return true, true
 
-	case m&os.ModeSymlink != 0:
+	case isSymlink(m):
 		return true, false
 	}
 
 	return false, false
+}
+
+// isSymlink checks if the provider file mode is a symlink
+// as of Go 1.23 Windows files with linked/mounted modes are considered irregular
+func isSymlink(m os.FileMode) bool {
+	return m&os.ModeSymlink != 0 || m&os.ModeIrregular != 0
 }


### PR DESCRIPTION
Adds checks for `os.ModeIrregular` anywhere where we were checking symlinks. This is required as of Go 1.23, additional discussion in golang/go#63703