### PR TITLE
sourceaddrs: support query paths in github and gitlab addresses

### DIFF
--- a/sourceaddrs/source_remote.go
+++ b/sourceaddrs/source_remote.go
@@ -162,7 +162,12 @@ var remoteSourceShorthands = []remoteSourceShorthand{
 			return "", false, nil
 		}
 
-		parts := strings.Split(given, "/")
+		url, query, _ := strings.Cut(given, "?")
+		if len(query) > 0 {
+			query = "?" + query
+		}
+
+		parts := strings.Split(url, "/")
 		if len(parts) < 3 {
 			return "", false, fmt.Errorf("GitHub.com shorthand addresses must start with github.com/organization/repository")
 		}
@@ -178,7 +183,7 @@ var remoteSourceShorthands = []remoteSourceShorthand{
 			urlStr += "//" + strings.Join(parts[3:], "/")
 		}
 
-		return "git::" + urlStr, true, nil
+		return fmt.Sprintf("git::%s%s", urlStr, query), true, nil
 	},
 	func(given string) (string, bool, error) {
 		// Allows a gitlab.com repository to be presented in a scheme-less
@@ -195,7 +200,12 @@ var remoteSourceShorthands = []remoteSourceShorthand{
 			return "", false, nil
 		}
 
-		parts := strings.Split(given, "/")
+		url, query, _ := strings.Cut(given, "?")
+		if len(query) > 0 {
+			query = "?" + query
+		}
+
+		parts := strings.Split(url, "/")
 		if len(parts) < 3 {
 			return "", false, fmt.Errorf("GitLab.com shorthand addresses must start with gitlab.com/organization/repository")
 		}
@@ -217,7 +227,7 @@ var remoteSourceShorthands = []remoteSourceShorthand{
 			// refer to a Git repository.
 		}
 
-		return "git::" + urlStr, true, nil
+		return fmt.Sprintf("git::%s%s", urlStr, query), true, nil
 	},
 }
 

--- a/sourceaddrs/source_test.go
+++ b/sourceaddrs/source_test.go
@@ -242,6 +242,25 @@ func TestParseSource(t *testing.T) {
 			},
 		},
 		{
+			Given: "github.com/hashicorp/stacks?ref=v4.8.0",
+			Want: RemoteSource{
+				pkg: RemotePackage{
+					sourceType: "git",
+					url:        *mustParseURL("https://github.com/hashicorp/stacks.git?ref=v4.8.0"),
+				},
+			},
+		},
+		{
+			Given: "github.com/hashicorp/stacks/bleep?ref=v4.8.0",
+			Want: RemoteSource{
+				pkg: RemotePackage{
+					sourceType: "git",
+					url:        *mustParseURL("https://github.com/hashicorp/stacks.git?ref=v4.8.0"),
+				},
+				subPath: "bleep",
+			},
+		},
+		{
 			Given: "gitlab.com/hashicorp/go-slug.git",
 			Want: RemoteSource{
 				pkg: RemotePackage{
@@ -256,6 +275,15 @@ func TestParseSource(t *testing.T) {
 				pkg: RemotePackage{
 					sourceType: "git",
 					url:        *mustParseURL("https://gitlab.com/hashicorp/go-slug.git"),
+				},
+			},
+		},
+		{
+			Given: "gitlab.com/hashicorp/stacks?ref=v4.8.0",
+			Want: RemoteSource{
+				pkg: RemotePackage{
+					sourceType: "git",
+					url:        *mustParseURL("https://gitlab.com/hashicorp/stacks.git?ref=v4.8.0"),
 				},
 			},
 		},


### PR DESCRIPTION
Internal ticket: https://hashicorp.atlassian.net/browse/TF-26710