### PR TITLE
fix(sourceaddrs): subpath handling for short-hand url expansion

### DIFF
--- a/sourceaddrs/source_remote.go
+++ b/sourceaddrs/source_remote.go
@@ -181,7 +181,7 @@ var remoteSourceShorthands = []remoteSourceShorthand{
 		if len(parts) > 3 {
 			// The remaining parts will become the sub-path portion, since
 			// the repository as a whole is the source package.
-			urlStr += "//" + strings.Join(parts[3:], "/")
+			urlStr += "//" + joinNonEmpty(parts[3:], "/")
 		}
 
 		return fmt.Sprintf("git::%s%s", urlStr, query), true, nil
@@ -219,7 +219,9 @@ var remoteSourceShorthands = []remoteSourceShorthand{
 		if len(parts) > 3 {
 			// The remaining parts will become the sub-path portion, since
 			// the repository as a whole is the source package.
-			urlStr += "//" + strings.Join(parts[3:], "/")
+			// The remaining parts will become the sub-path portion, since
+			// the repository as a whole is the source package.
+			urlStr += "//" + joinNonEmpty(parts[3:], "/")
 			// NOTE: We can't actually get here if there are exactly four
 			// parts, because gitlab.com is also a Terraform module registry
 			// and so gitlab.com/a/b/c must be interpreted as a registry
@@ -230,6 +232,17 @@ var remoteSourceShorthands = []remoteSourceShorthand{
 
 		return fmt.Sprintf("git::%s%s", urlStr, query), true, nil
 	},
+}
+
+func joinNonEmpty(parts []string, sep string) string {
+	filtered := []string{}
+	for _, p := range parts {
+		if p != "" {
+			filtered = append(filtered, p)
+		}
+	}
+
+	return strings.Join(filtered, sep)
 }
 
 var remoteSourceTypePattern = regexp.MustCompile(`^([A-Za-z0-9]+)::(.+)$`)

--- a/sourceaddrs/source_remote.go
+++ b/sourceaddrs/source_remote.go
@@ -219,8 +219,6 @@ var remoteSourceShorthands = []remoteSourceShorthand{
 		if len(parts) > 3 {
 			// The remaining parts will become the sub-path portion, since
 			// the repository as a whole is the source package.
-			// The remaining parts will become the sub-path portion, since
-			// the repository as a whole is the source package.
 			urlStr += "//" + trimSubpath(parts[3:])
 			// NOTE: We can't actually get here if there are exactly four
 			// parts, because gitlab.com is also a Terraform module registry

--- a/sourceaddrs/source_remote.go
+++ b/sourceaddrs/source_remote.go
@@ -181,7 +181,7 @@ var remoteSourceShorthands = []remoteSourceShorthand{
 		if len(parts) > 3 {
 			// The remaining parts will become the sub-path portion, since
 			// the repository as a whole is the source package.
-			urlStr += "//" + joinNonEmpty(parts[3:], "/")
+			urlStr += "//" + trimSubpath(parts[3:])
 		}
 
 		return fmt.Sprintf("git::%s%s", urlStr, query), true, nil
@@ -221,7 +221,7 @@ var remoteSourceShorthands = []remoteSourceShorthand{
 			// the repository as a whole is the source package.
 			// The remaining parts will become the sub-path portion, since
 			// the repository as a whole is the source package.
-			urlStr += "//" + joinNonEmpty(parts[3:], "/")
+			urlStr += "//" + trimSubpath(parts[3:])
 			// NOTE: We can't actually get here if there are exactly four
 			// parts, because gitlab.com is also a Terraform module registry
 			// and so gitlab.com/a/b/c must be interpreted as a registry
@@ -234,15 +234,19 @@ var remoteSourceShorthands = []remoteSourceShorthand{
 	},
 }
 
-func joinNonEmpty(parts []string, sep string) string {
+// Removes the first leading empty string from the slice,
+// if present. Subsequent empty strings (such as those resulting from consecutive
+// slashes, e.g., "//") are preserved in their positions.
+func trimSubpath(parts []string) string {
 	filtered := []string{}
-	for _, p := range parts {
-		if p != "" {
+	for i, p := range parts {
+		// Only filter leading empty positions in slice
+		if p != "" || i > 0 {
 			filtered = append(filtered, p)
 		}
 	}
 
-	return strings.Join(filtered, sep)
+	return strings.Join(filtered, "/")
 }
 
 var remoteSourceTypePattern = regexp.MustCompile(`^([A-Za-z0-9]+)::(.+)$`)

--- a/sourceaddrs/source_test.go
+++ b/sourceaddrs/source_test.go
@@ -232,6 +232,26 @@ func TestParseSource(t *testing.T) {
 			},
 		},
 		{
+			Given: "github.com/hashicorp/stacks.git//path/to/dir",
+			Want: RemoteSource{
+				pkg: RemotePackage{
+					sourceType: "git",
+					url:        *mustParseURL("https://github.com/hashicorp/stacks.git"),
+				},
+				subPath: "path/to/dir",
+			},
+		},
+		{
+			Given: "github.com/hashicorp/stacks//path/to/dir?ref=main",
+			Want: RemoteSource{
+				pkg: RemotePackage{
+					sourceType: "git",
+					url:        *mustParseURL("https://github.com/hashicorp/stacks.git?ref=main"),
+				},
+				subPath: "path/to/dir",
+			},
+		},
+		{
 			Given: "github.com/hashicorp/go-slug/bleep",
 			Want: RemoteSource{
 				pkg: RemotePackage{
@@ -285,6 +305,26 @@ func TestParseSource(t *testing.T) {
 					sourceType: "git",
 					url:        *mustParseURL("https://gitlab.com/hashicorp/stacks.git?ref=v4.8.0"),
 				},
+			},
+		},
+		{
+			Given: "gitlab.com/hashicorp/stacks.git//path/to/dir",
+			Want: RemoteSource{
+				pkg: RemotePackage{
+					sourceType: "git",
+					url:        *mustParseURL("https://gitlab.com/hashicorp/stacks.git"),
+				},
+				subPath: "path/to/dir",
+			},
+		},
+		{
+			Given: "gitlab.com/hashicorp/stacks//path/to/dir?ref=main",
+			Want: RemoteSource{
+				pkg: RemotePackage{
+					sourceType: "git",
+					url:        *mustParseURL("https://gitlab.com/hashicorp/stacks.git?ref=main"),
+				},
+				subPath: "path/to/dir",
 			},
 		},
 		{

--- a/sourceaddrs/source_test.go
+++ b/sourceaddrs/source_test.go
@@ -465,6 +465,10 @@ func TestParseSource(t *testing.T) {
 			Given:   "https://:bar@example.com/foo.tgz",
 			WantErr: `invalid remote source address "https://:bar@example.com/foo.tgz": must not use username or password in URL portion`,
 		},
+		{
+			Given:   "github.com/hashicorp/stacks//path/to/dir//invalid?ref=main",
+			WantErr: `invalid remote source address "github.com/hashicorp/stacks//path/to/dir//invalid?ref=main": invalid sub-path: must be slash-separated relative path without any .. or . segments`,
+		},
 	}
 
 	for _, test := range tests {

--- a/sourceaddrs/source_test.go
+++ b/sourceaddrs/source_test.go
@@ -328,6 +328,16 @@ func TestParseSource(t *testing.T) {
 			},
 		},
 		{
+			Given: "gitlab.com/hashicorp/stacks.git//path/to/dir?ref=main",
+			Want: RemoteSource{
+				pkg: RemotePackage{
+					sourceType: "git",
+					url:        *mustParseURL("https://gitlab.com/hashicorp/stacks.git?ref=main"),
+				},
+				subPath: "path/to/dir",
+			},
+		},
+		{
 			Given: "gitlab.com/hashicorp/go-slug/bleep",
 			// NOTE: gitlab.com _also_ hosts a Terraform Module registry, and so
 			// the registry address interpretation takes precedence if it


### PR DESCRIPTION
## Description

The source address expansion handling for shorthand URLs (GitHub, GitLab) that include a subpath is currently broken. If a valid shorthand slug includes a subpath, the user receives an incorrect format error message. This revision ensures that empty strings are excluded when building the full source address.

Example Error message
```
invalid remote source address "gitlab.com/hashicorp/stacks.git//path/to/dir?ref=v4.8.0": invalid sub-path: must be slash-separated relative path without any .. or . segments
```

## Related Issue

<!-- If this PR is linked to any issue, provide the issue number or description here. Any related JIRA tickets can also be added here. -->

## How Has This Been Tested?

<!-- Describe how the changes have been tested. Provide test instructions or details. -->
